### PR TITLE
Fallback execution of test cases

### DIFF
--- a/TryAtSoftware.CleanTests.Core/Extensions/CleanTestsFrameworkExtensions.cs
+++ b/TryAtSoftware.CleanTests.Core/Extensions/CleanTestsFrameworkExtensions.cs
@@ -6,7 +6,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using TryAtSoftware.CleanTests.Core.Interfaces;
+using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using TryAtSoftware.Extensions.Collections;
+using Xunit.Sdk;
 
 public static class CleanTestsFrameworkExtensions
 {
@@ -28,6 +30,19 @@ public static class CleanTestsFrameworkExtensions
         if (demands is null) throw new ArgumentNullException(nameof(demands));
 
         return utilitiesCollection.Get(category).OrEmptyIfNull().IgnoreNullValues().Where(iu => demands.All(iu.ContainsCharacteristic)).ToArray();
+    }
+
+    internal static (List<ICleanTestCase> CleanTestCases, List<IXunitTestCase> OtherTestCases) ExtractCleanTestCases(this IEnumerable<IXunitTestCase>? testCases)
+    {
+        var cleanTestCases = new List<ICleanTestCase>();
+        var otherTestCases = new List<IXunitTestCase>();
+        foreach (var testCase in testCases.OrEmptyIfNull().IgnoreNullValues())
+        {
+            if (testCase is ICleanTestCase ctc) cleanTestCases.Add(ctc);
+            else otherTestCases.Add(testCase);
+        }
+
+        return (cleanTestCases, otherTestCases);
     }
 
     internal static Assembly? LoadAssemblySafely(string assemblyName)

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/FallbackTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/FallbackTestFrameworkDiscoverer.cs
@@ -1,0 +1,15 @@
+﻿namespace TryAtSoftware.CleanTests.Core.XUnit.Discovery;
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+public class FallbackTestFrameworkDiscoverer : XunitTestFrameworkDiscoverer
+{
+    public FallbackTestFrameworkDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider, IMessageSink diagnosticMessageSink, IXunitTestCollectionFactory? collectionFactory = null)
+        : base(assemblyInfo, sourceProvider, diagnosticMessageSink, collectionFactory)
+    {
+    }
+
+    public void DiscoverFallbackTests(ITestMethod testMethod, bool includeSourceInformation, IMessageBus messageBus, ITestFrameworkDiscoveryOptions discoveryOptions)
+        => this.FindTestsForMethod(testMethod, includeSourceInformation, messageBus, discoveryOptions);
+}

--- a/TryAtSoftware.CleanTests.Sample/StandardTest.cs
+++ b/TryAtSoftware.CleanTests.Sample/StandardTest.cs
@@ -16,9 +16,17 @@ public class StandardTest : CleanTest
     }
 
     [CleanFact]
+    public void CleanFact() => Assert.Equal(4, 2 + 2);
+
+    [Fact]
     public void StandardFact() => Assert.Equal(4, 2 + 2);
 
     [CleanTheory]
+    [InlineData(1, 2, 3)]
+    [InlineData(5, 10, 15)]
+    public void CleanTheory(int a, int b, int expected) => Assert.Equal(expected, a + b);
+    
+    [Theory]
     [InlineData(1, 2, 3)]
     [InlineData(5, 10, 15)]
     public void StandardTheory(int a, int b, int expected) => Assert.Equal(expected, a + b);


### PR DESCRIPTION
Tests that are not marked with the `CleanFact` or `CleanTheory` attribute will still be discovered and execute by default.
