### PR TITLE
Added a base class for clean tests and improved the experience in VS

### DIFF
--- a/TryAtSoftware.CleanTests.Core/Attributes/TestSuiteAttribute.cs
+++ b/TryAtSoftware.CleanTests.Core/Attributes/TestSuiteAttribute.cs
@@ -1,8 +1,0 @@
-﻿namespace TryAtSoftware.CleanTests.Core.Attributes;
-
-using System;
-
-[AttributeUsage(AttributeTargets.Class)]
-public class TestSuiteAttribute : Attribute
-{
-}

--- a/TryAtSoftware.CleanTests.Core/CleanTest.cs
+++ b/TryAtSoftware.CleanTests.Core/CleanTest.cs
@@ -53,7 +53,7 @@ public abstract class CleanTest : ICleanTest, IDisposable, IAsyncLifetime
 
     protected virtual void Dispose(bool disposing)
     {
-        if (disposing == false) return;
+        if (!disposing) return;
 
         this._scope?.Dispose();
         this._localDependenciesProvider?.Dispose();

--- a/TryAtSoftware.CleanTests.Core/CleanTest.cs
+++ b/TryAtSoftware.CleanTests.Core/CleanTest.cs
@@ -1,27 +1,26 @@
-﻿namespace TryAtSoftware.CleanTests.Sample;
+namespace TryAtSoftware.CleanTests.Core;
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using TryAtSoftware.CleanTests.Core.Attributes;
 using TryAtSoftware.CleanTests.Core.Interfaces;
-using TryAtSoftware.CleanTests.Sample.Attributes;
+using Xunit;
 using Xunit.Abstractions;
 
-[TestSuite]
-[TestSuiteGenericTypeMapping(typeof(NumericAttribute), typeof(int))]
-public class CleanTest : ICleanTest, IDisposable, IAsyncLifetime
+public abstract class CleanTest : ICleanTest, IDisposable, IAsyncLifetime
 {
     private ServiceProvider? _localDependenciesProvider;
     private IServiceScope? _scope;
-    
+
     private ServiceProvider? _globalDependenciesProvider;
 
-    public CleanTest(ITestOutputHelper testOutputHelper)
+    protected CleanTest(ITestOutputHelper testOutputHelper)
     {
         this.TestOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
     }
 
     protected ITestOutputHelper TestOutputHelper { get; }
-    
+
     public IServiceCollection LocalDependenciesCollection { get; } = new ServiceCollection();
     public IServiceCollection GlobalDependenciesCollection { get; } = new ServiceCollection();
 
@@ -29,13 +28,13 @@ public class CleanTest : ICleanTest, IDisposable, IAsyncLifetime
     {
         var serviceProviderOptions = new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true };
         this._globalDependenciesProvider = this.GlobalDependenciesCollection.BuildServiceProvider(serviceProviderOptions);
-        
+
         this._localDependenciesProvider = this.LocalDependenciesCollection.BuildServiceProvider(serviceProviderOptions);
         this._scope = this._localDependenciesProvider.CreateScope();
 
         return Task.CompletedTask;
     }
-    
+
     protected TService GetGlobalService<TService>()
         where TService : notnull
     {

--- a/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
+++ b/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
@@ -23,11 +23,7 @@
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
         <PackageReference Include="TryAtSoftware.Extensions.Collections" Version="1.0.1" />
         <PackageReference Include="TryAtSoftware.Extensions.Reflection" Version="1.0.1" />
-        <PackageReference Include="xunit.core" Version="2.4.2" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="XUnit\Data" />
+        <PackageReference Include="xunit" Version="2.4.2" />
     </ItemGroup>
 
 </Project>

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
@@ -1,4 +1,4 @@
-﻿namespace TryAtSoftware.CleanTests.Core.XUnit;
+namespace TryAtSoftware.CleanTests.Core.XUnit;
 
 using System;
 using System.Linq;
@@ -88,12 +88,13 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
 
     public override void Deserialize(IXunitSerializationInfo data)
     {
-        base.Deserialize(data);
         var deserializedCleanTestData = data.GetValue<SerializableCleanTestCaseData>("ctd");
         this.CleanTestCaseData = deserializedCleanTestData.CleanTestData;
         
         var deserializedAssemblyData = data.GetValue<SerializableCleanTestAssemblyData>("ad");
         this.CleanTestAssemblyData = deserializedAssemblyData.CleanTestData;
+
+        base.Deserialize(data);
     }
 
     protected override string GetUniqueID()

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestFramework.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestFramework.cs
@@ -51,8 +51,9 @@ public class CleanTestFramework : XunitTestFramework
             var initializationUtilityAttributes = type.GetCustomAttributes(typeof(CleanUtilityAttribute)).ToArray();
             if (initializationUtilityAttributes.Length == 0) continue;
 
-            var internalDemands = ExtractDemands<InternalDemandsAttribute>(type);
-            var externalDemands = ExtractDemands<ExternalDemandsAttribute>(type);
+            var decoratedType = new DecoratedType(type);
+            var internalDemands = decoratedType.ExtractDemands<InternalDemandsAttribute>();
+            var externalDemands = decoratedType.ExtractDemands<ExternalDemandsAttribute>();
             var requirements = ExtractRequirements(type);
 
             foreach (var utilityAttribute in initializationUtilityAttributes.OrEmptyIfNull().IgnoreNullValues())
@@ -69,20 +70,6 @@ public class CleanTestFramework : XunitTestFramework
                 utilitiesCollection.Register(categoryArgument, initializationUtility);
             }
         }
-    }
-
-    private static ICleanTestInitializationCollection<string> ExtractDemands<TAttribute>(ITypeInfo type)
-        where TAttribute : BaseDemandsAttribute
-    {
-        var demands = new CleanTestInitializationCollection<string>();
-        foreach (var attribute in type.GetCustomAttributes(typeof(TAttribute)))
-        {
-            var demandsArgument = attribute.GetNamedArgument<IEnumerable<string>>(nameof(BaseDemandsAttribute.Demands));
-            var categoryArgument = attribute.GetNamedArgument<string>(nameof(BaseDemandsAttribute.Category));
-            foreach (var demand in demandsArgument) demands.Register(categoryArgument, demand);
-        }
-
-        return demands;
     }
 
     private static HashSet<string> ExtractRequirements(ITypeInfo type)

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
@@ -9,6 +9,7 @@ using TryAtSoftware.CleanTests.Core.Extensions;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.CleanTests.Core.XUnit.Extensions;
 using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
+using TryAtSoftware.CleanTests.Core.XUnit.Wrappers;
 using TryAtSoftware.Extensions.Collections;
 using TryAtSoftware.Extensions.Reflection;
 using Xunit;
@@ -53,7 +54,7 @@ public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
         // After: MetadataColoringCleanTests<Int64>
         var wrappedXUnitTypeInfo = new CleanTestReflectionTypeInfoWrapper(xUnitTypeInfo);
 
-        return new TestClass(collection, wrappedXUnitTypeInfo);
+        return new CleanTestClassWrapper(collection, wrappedXUnitTypeInfo, xUnitTypeInfo.Name);
     }
 
     /// <inheritdoc />

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
@@ -108,21 +108,12 @@ public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
 
         var initializationRequirements = ExtractRequirements(method);
 
-        var demands = new Dictionary<string, HashSet<string>>();
-        var demandsAttributeType = typeof(TestDemandsAttribute);
-        foreach (var attribute in method.GetCustomAttributes(demandsAttributeType).OrEmptyIfNull().IgnoreNullValues())
-        {
-            var currentDemandsCategory = attribute.GetNamedArgument<string>("Category");
-            var currentDemands = attribute.GetNamedArgument<IEnumerable<string>>("Demands");
-
-            var categorizedDemands = demands.EnsureValue(currentDemandsCategory);
-            foreach (var currentDemand in currentDemands.OrEmptyIfNull().IgnoreNullOrWhitespaceValues()) categorizedDemands.Add(currentDemand);
-        }
+        var demands = method.ExtractDemands<TestDemandsAttribute>();
 
         var allRequirementSources = new[] { initializationRequirements, globalRequirements };
         foreach (var category in allRequirementSources.SetIntersection())
         {
-            var categoryDemands = demands.GetValueOrDefault(category) ?? new HashSet<string>();
+            var categoryDemands = demands.Get(category);
             foreach (var initializationUtility in this._utilitiesCollection.Get(category, categoryDemands)) customInitializationUtilitiesCollection.Register(category, initializationUtility);
         }
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/Wrappers/CleanTestClassWrapper.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Wrappers/CleanTestClassWrapper.cs
@@ -1,0 +1,80 @@
+﻿namespace TryAtSoftware.CleanTests.Core.XUnit.Wrappers;
+
+using System;
+using TryAtSoftware.CleanTests.Core.Extensions;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+public class CleanTestClassWrapper : ITestClass
+{
+    private ITestCollection? _testCollection;
+    private ITypeInfo? _class;
+    private string? _fullyQualifiedTypeName;
+    
+    public CleanTestClassWrapper()
+    {
+    }
+    
+    public CleanTestClassWrapper(ITestCollection testCollection, ITypeInfo type, string fullyQualifiedTypeName)
+    {
+        this.TestCollection = testCollection ?? throw new ArgumentNullException(nameof(testCollection));
+        this.Class = type ?? throw new ArgumentNullException(nameof(type));
+
+        if (string.IsNullOrWhiteSpace(fullyQualifiedTypeName)) throw new ArgumentNullException(nameof(fullyQualifiedTypeName));
+        this.FullyQualifiedTypeName = fullyQualifiedTypeName;
+    }
+
+    public ITestCollection TestCollection
+    {
+        get
+        {
+            this._testCollection.ValidateInstantiated("test collection");
+            return this._testCollection;
+        }
+        private set => this._testCollection = value;
+    }
+
+    public ITypeInfo Class
+    {
+        get
+        {
+            this._class.ValidateInstantiated("class");
+            return this._class;
+        }
+        private set => this._class = value;
+    }
+
+    private string FullyQualifiedTypeName
+    {
+        get
+        {
+            this._fullyQualifiedTypeName.ValidateInstantiated("fully qualified type name");
+            return this._fullyQualifiedTypeName;
+        }
+        set => this._fullyQualifiedTypeName = value;
+    }
+
+    public void Serialize(IXunitSerializationInfo info)
+    {
+        info.AddValue("an", this.Class.Assembly.Name);
+        info.AddValue("cn", this._fullyQualifiedTypeName);
+        info.AddValue("c", this.TestCollection);
+    }
+    
+    public void Deserialize(IXunitSerializationInfo info)
+    {
+        this.TestCollection = info.GetValue<ITestCollection>("c");
+
+        this.FullyQualifiedTypeName = info.GetValue<string>("cn");
+        var assemblyName = info.GetValue<string>("an");
+        
+        var assembly = CleanTestsFrameworkExtensions.LoadAssemblySafely(assemblyName);
+        if (assembly is null) throw new InvalidOperationException($"Assembly '{assembly}' was not loaded successfully");
+
+        var type = assembly.GetType(this.FullyQualifiedTypeName);
+        if (type is null) throw new InvalidOperationException($"Type '{this.FullyQualifiedTypeName}' was not found in assembly '{assemblyName}'.");
+
+        var xUnitTypeInfo = Reflector.Wrap(type);
+        this.Class = new CleanTestReflectionTypeInfoWrapper(xUnitTypeInfo);
+    }
+}

--- a/TryAtSoftware.CleanTests.Core/XUnit/Wrappers/CleanTestReflectionTypeInfoWrapper.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Wrappers/CleanTestReflectionTypeInfoWrapper.cs
@@ -1,4 +1,4 @@
-﻿namespace TryAtSoftware.CleanTests.Core.XUnit;
+﻿namespace TryAtSoftware.CleanTests.Core.XUnit.Wrappers;
 
 using System;
 using System.Collections.Generic;

--- a/TryAtSoftware.CleanTests.Sample/GenericTest.cs
+++ b/TryAtSoftware.CleanTests.Sample/GenericTest.cs
@@ -1,9 +1,11 @@
 ﻿namespace TryAtSoftware.CleanTests.Sample;
 
+using TryAtSoftware.CleanTests.Core;
 using TryAtSoftware.CleanTests.Core.Attributes;
 using TryAtSoftware.CleanTests.Sample.Attributes;
 using Xunit.Abstractions;
 
+[TestSuiteGenericTypeMapping(typeof(NumericAttribute), typeof(int))]
 public class GenericTest<[Numeric] T> : CleanTest
     where T : notnull
 {

--- a/TryAtSoftware.CleanTests.Sample/SampleCleanTest.cs
+++ b/TryAtSoftware.CleanTests.Sample/SampleCleanTest.cs
@@ -1,0 +1,95 @@
+namespace TryAtSoftware.CleanTests.Sample;
+
+using TryAtSoftware.CleanTests.Core;
+using TryAtSoftware.CleanTests.Core.Attributes;
+using TryAtSoftware.CleanTests.Sample.Mathematics;
+using TryAtSoftware.CleanTests.Sample.Utilities;
+using TryAtSoftware.CleanTests.Sample.Utilities.Creations;
+using TryAtSoftware.CleanTests.Sample.Utilities.People;
+using TryAtSoftware.Extensions.Reflection;
+using Xunit.Abstractions;
+
+public class SampleCleanTest : CleanTest
+{
+    public SampleCleanTest(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    [CleanFact]
+    public void CleanFact() => Assert.Equal(4, 2 + 2);
+
+    [Fact]
+    public void StandardFact() => Assert.Equal(4, 2 + 2);
+
+    [CleanTheory]
+    [InlineData(1, 2, 3)]
+    [InlineData(5, 10, 15)]
+    public void CleanTheory(int a, int b, int expected) => Assert.Equal(expected, a + b);
+    
+    [Theory]
+    [InlineData(1, 2, 3)]
+    [InlineData(5, 10, 15)]
+    public void StandardTheory(int a, int b, int expected) => Assert.Equal(expected, a + b);
+
+    [CleanFact]
+    [WithRequirements(Categories.People)]
+    public void TestUtilityDistribution()
+    {
+        var person = this.GetService<IPerson>();
+        Assert.NotNull(person);
+
+        this.OutputUtilityInfo(person);
+    }
+    
+    [CleanFact]
+    [WithRequirements(Categories.Creations)]
+    public void TestUtilityDistributionWithInternalDependencies()
+    {
+        var creation = this.GetService<ICreation>();
+        Assert.NotNull(creation);
+
+        this.OutputUtilityInfo(creation);
+    }
+    
+    [CleanFact]
+    [WithRequirements(Categories.People, Categories.Creations)]
+    public void TestComplexUtilityDistribution()
+    {
+        var person = this.GetService<IPerson>();
+        Assert.NotNull(person);
+        
+        var creation = this.GetService<ICreation>();
+        Assert.NotNull(creation);
+
+        this.OutputUtilityInfo(person);
+        this.OutputUtilityInfo(creation);
+    }
+
+    [CleanFact]
+    [WithRequirements(Categories.People)]
+    [TestDemands(Categories.People, Characteristics.KnownPerson)]
+    public void TestUtilityDistributionWithDemands()
+    {
+        var person = this.GetService<IPerson>();
+        Assert.NotNull(person);
+
+        this.OutputUtilityInfo(person);
+    }
+
+    [CleanFact]
+    [WithRequirements(MathConstants.Category)]
+    public void TestSharedUtilityDistribution()
+    {
+        var mathFunction = this.GetService<IMathFunction>();
+        Assert.NotNull(mathFunction);
+        
+        this.OutputUtilityInfo(mathFunction);
+    }
+
+    private void OutputUtilityInfo<T>(T utility)
+    {
+        Assert.NotNull(utility);
+        this.TestOutputHelper.WriteLine($"The used test utility is of type: {TypeNames.Get(utility.GetType())}");
+    }
+}

--- a/TryAtSoftware.CleanTests.Sample/StandardTest.cs
+++ b/TryAtSoftware.CleanTests.Sample/StandardTest.cs
@@ -1,20 +1,9 @@
-﻿namespace TryAtSoftware.CleanTests.Sample;
+namespace TryAtSoftware.CleanTests.Sample;
 
 using TryAtSoftware.CleanTests.Core.Attributes;
-using TryAtSoftware.CleanTests.Sample.Mathematics;
-using TryAtSoftware.CleanTests.Sample.Utilities;
-using TryAtSoftware.CleanTests.Sample.Utilities.Creations;
-using TryAtSoftware.CleanTests.Sample.Utilities.People;
-using TryAtSoftware.Extensions.Reflection;
-using Xunit.Abstractions;
 
-public class StandardTest : CleanTest
+public class StandardTest
 {
-    public StandardTest(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
-    }
-
     [CleanFact]
     public void CleanFact() => Assert.Equal(4, 2 + 2);
 
@@ -30,65 +19,4 @@ public class StandardTest : CleanTest
     [InlineData(1, 2, 3)]
     [InlineData(5, 10, 15)]
     public void StandardTheory(int a, int b, int expected) => Assert.Equal(expected, a + b);
-
-    [CleanFact]
-    [WithRequirements(Categories.People)]
-    public void TestUtilityDistribution()
-    {
-        var person = this.GetService<IPerson>();
-        Assert.NotNull(person);
-
-        this.OutputUtilityInfo(person);
-    }
-    
-    [CleanFact]
-    [WithRequirements(Categories.Creations)]
-    public void TestUtilityDistributionWithInternalDependencies()
-    {
-        var creation = this.GetService<ICreation>();
-        Assert.NotNull(creation);
-
-        this.OutputUtilityInfo(creation);
-    }
-    
-    [CleanFact]
-    [WithRequirements(Categories.People, Categories.Creations)]
-    public void TestComplexUtilityDistribution()
-    {
-        var person = this.GetService<IPerson>();
-        Assert.NotNull(person);
-        
-        var creation = this.GetService<ICreation>();
-        Assert.NotNull(creation);
-
-        this.OutputUtilityInfo(person);
-        this.OutputUtilityInfo(creation);
-    }
-
-    [CleanFact]
-    [WithRequirements(Categories.People)]
-    [TestDemands(Categories.People, Characteristics.KnownPerson)]
-    public void TestUtilityDistributionWithDemands()
-    {
-        var person = this.GetService<IPerson>();
-        Assert.NotNull(person);
-
-        this.OutputUtilityInfo(person);
-    }
-
-    [CleanFact]
-    [WithRequirements(MathConstants.Category)]
-    public void TestSharedUtilityDistribution()
-    {
-        var mathFunction = this.GetService<IMathFunction>();
-        Assert.NotNull(mathFunction);
-        
-        this.OutputUtilityInfo(mathFunction);
-    }
-
-    private void OutputUtilityInfo<T>(T utility)
-    {
-        Assert.NotNull(utility);
-        this.TestOutputHelper.WriteLine($"The used test utility is of type: {TypeNames.Get(utility.GetType())}");
-    }
 }


### PR DESCRIPTION
- Removed the `TestSuite` attribute as it only made things even more complex
- Improved the serialization/deserialization of various data classes so that clean tests can be successfully executed within VS