### PR TITLE
Global utilities management and Visual Studio integration improvements

### DIFF
--- a/.github/workflows/Publish packages.yml
+++ b/.github/workflows/Publish packages.yml
@@ -14,21 +14,21 @@ jobs:
       NUGET_SOURCE: https://api.nuget.org/v3/index.json
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 7.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 7.x
 
-    - name: Restore dependencies
-      run: dotnet restore
+      - name: Restore dependencies
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --no-restore --configuration "${{ env.CONFIGURATION }}"
+      - name: Build
+        run: dotnet build --no-restore --configuration "${{ env.CONFIGURATION }}"
 
-    - name: Pack 'Equalizer'
-      run: dotnet pack --no-build --configuration "${{ env.CONFIGURATION }}" ./TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj -o "${{ env.PACKAGES_DIRECTORY }}"
+      - name: Pack 'Clean tests'
+        run: dotnet pack --no-build --configuration "${{ env.CONFIGURATION }}" ./TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj -o "${{ env.PACKAGES_DIRECTORY }}"
 
-    - name: Publish all packages
-      run: dotnet nuget push "${{ env.PACKAGES_DIRECTORY }}/*.nupkg" --source "${{ env.NUGET_SOURCE }}" --api-key "${{ env.NUGET_KEY }}" --skip-duplicate
+      - name: Publish all packages
+        run: dotnet nuget push "${{ env.PACKAGES_DIRECTORY }}/*.nupkg" --source "${{ env.NUGET_SOURCE }}" --api-key "${{ env.NUGET_KEY }}" --skip-duplicate

--- a/TryAtSoftware.CleanTests.Core/CleanUtilityDescriptor.cs
+++ b/TryAtSoftware.CleanTests.Core/CleanUtilityDescriptor.cs
@@ -19,7 +19,7 @@ public class CleanUtilityDescriptor : ICleanUtilityDescriptor
     public Type Type { get; }
 
     /// <inheritdoc />
-    public string DisplayName { get; }
+    public string Name { get; }
 
     /// <inheritdoc />
     public bool IsGlobal { get; }
@@ -41,7 +41,7 @@ public class CleanUtilityDescriptor : ICleanUtilityDescriptor
         this.Category = initializationCategory;
         this.Id = id;
         this.Type = type ?? throw new ArgumentNullException(nameof(type));
-        this.DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+        this.Name = displayName ?? throw new ArgumentNullException(nameof(displayName));
         this.IsGlobal = isGlobal;
         foreach (var characteristic in characteristics.OrEmptyIfNull().IgnoreNullOrWhitespaceValues()) this._characteristics.Add(characteristic);
         foreach (var requirement in requirements.OrEmptyIfNull().IgnoreNullOrWhitespaceValues()) this.InternalRequirements.Add(requirement);

--- a/TryAtSoftware.CleanTests.Core/GlobalUtilitiesProvider.cs
+++ b/TryAtSoftware.CleanTests.Core/GlobalUtilitiesProvider.cs
@@ -1,9 +1,10 @@
-﻿namespace TryAtSoftware.CleanTests.Core.Utilities;
+﻿namespace TryAtSoftware.CleanTests.Core;
 
 using System;
 using System.Collections.Generic;
+using TryAtSoftware.CleanTests.Core.Interfaces;
 
-public class GlobalUtilitiesProvider
+public class GlobalUtilitiesProvider : IGlobalUtilitiesProvider
 {
     private readonly Dictionary<string, object> _utilities = new ();
 

--- a/TryAtSoftware.CleanTests.Core/Interfaces/ICleanUtilityDescriptor.cs
+++ b/TryAtSoftware.CleanTests.Core/Interfaces/ICleanUtilityDescriptor.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 public interface ICleanUtilityDescriptor
 {
     string Category { get; }
-    Guid Id { get; }
+    string Id => $"c:{this.Category}|n:{this.Name}";
         
     Type Type { get; }
-    string DisplayName { get; }
+    string Name { get; }
     bool IsGlobal { get; }
     
     IReadOnlyCollection<string> Characteristics { get; }

--- a/TryAtSoftware.CleanTests.Core/Interfaces/IGlobalUtilitiesProvider.cs
+++ b/TryAtSoftware.CleanTests.Core/Interfaces/IGlobalUtilitiesProvider.cs
@@ -1,0 +1,10 @@
+namespace TryAtSoftware.CleanTests.Core.Interfaces;
+
+using System.Collections.Generic;
+
+public interface IGlobalUtilitiesProvider
+{
+    bool AddUtility(string uniqueId, object instance);
+    object? GetUtility(string uniqueId);
+    IEnumerable<T> GetUtilities<T>();
+}

--- a/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
+++ b/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
@@ -8,7 +8,7 @@
         <SonarQubeTestProject>false</SonarQubeTestProject>
 
         <PackageId>TryAtSoftware.CleanTests</PackageId>
-        <Version>1.0.0-alpha.2</Version>
+        <Version>1.0.0-alpha.3</Version>
         <Authors>Tony Troeff</Authors>
         <RepositoryUrl>https://github.com/TryAtSoftware/CleanTests</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/TryAtSoftware.CleanTests.Core/Utilities/GlobalUtilitiesProvider.cs
+++ b/TryAtSoftware.CleanTests.Core/Utilities/GlobalUtilitiesProvider.cs
@@ -5,29 +5,25 @@ using System.Collections.Generic;
 
 public class GlobalUtilitiesProvider
 {
-    private readonly Dictionary<string, Dictionary<Type, object>> _utilities = new ();
+    private readonly Dictionary<string, object> _utilities = new ();
 
-    public bool AddUtility(string uniqueId, Type type, object instance)
+    public bool AddUtility(string uniqueId, object instance)
     {
         if (!this._utilities.ContainsKey(uniqueId)) this._utilities[uniqueId] = new Dictionary<Type, object>();
-        if (this._utilities[uniqueId].ContainsKey(type)) return false;
 
-        this._utilities[uniqueId][type] = instance;
+        this._utilities[uniqueId] = instance;
         return true;
     }
 
-    public object? GetUtility(string uniqueId, Type type)
+    public object? GetUtility(string uniqueId)
     {
-        if (!this._utilities.ContainsKey(uniqueId) || !this._utilities[uniqueId].ContainsKey(type)) return null;
-        return this._utilities[uniqueId][type];
+        if (!this._utilities.ContainsKey(uniqueId)) return null;
+        return this._utilities[uniqueId];
     }
 
     public IEnumerable<T> GetUtilities<T>()
     {
-        foreach (var (_, ubt) in this._utilities)
-        {
-            foreach (var (_, utility) in ubt)
-                if (utility is T t) yield return t;
-        }
+        foreach (var (_, utility) in this._utilities)
+            if (utility is T t) yield return t;
     }
 }

--- a/TryAtSoftware.CleanTests.Core/Utilities/GlobalUtilitiesProvider.cs
+++ b/TryAtSoftware.CleanTests.Core/Utilities/GlobalUtilitiesProvider.cs
@@ -1,0 +1,33 @@
+﻿namespace TryAtSoftware.CleanTests.Core.Utilities;
+
+using System;
+using System.Collections.Generic;
+
+public class GlobalUtilitiesProvider
+{
+    private readonly Dictionary<string, Dictionary<Type, object>> _utilities = new ();
+
+    public bool AddUtility(string uniqueId, Type type, object instance)
+    {
+        if (!this._utilities.ContainsKey(uniqueId)) this._utilities[uniqueId] = new Dictionary<Type, object>();
+        if (this._utilities[uniqueId].ContainsKey(type)) return false;
+
+        this._utilities[uniqueId][type] = instance;
+        return true;
+    }
+
+    public object? GetUtility(string uniqueId, Type type)
+    {
+        if (!this._utilities.ContainsKey(uniqueId) || !this._utilities[uniqueId].ContainsKey(type)) return null;
+        return this._utilities[uniqueId][type];
+    }
+
+    public IEnumerable<T> GetUtilities<T>()
+    {
+        foreach (var (_, ubt) in this._utilities)
+        {
+            foreach (var (_, utility) in ubt)
+                if (utility is T t) yield return t;
+        }
+    }
+}

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestAssemblyData.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestAssemblyData.cs
@@ -1,6 +1,5 @@
 ﻿namespace TryAtSoftware.CleanTests.Core.XUnit;
 
-using System;
 using System.Collections.Generic;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.Extensions.Collections;
@@ -8,7 +7,7 @@ using TryAtSoftware.Extensions.Collections;
 public class CleanTestAssemblyData
 {
     public ICleanTestInitializationCollection<ICleanUtilityDescriptor> CleanUtilities { get; } = new CleanTestInitializationCollection<ICleanUtilityDescriptor>();
-    public IDictionary<Guid, ICleanUtilityDescriptor> CleanUtilitiesById { get; } = new Dictionary<Guid, ICleanUtilityDescriptor>();
+    public IDictionary<string, ICleanUtilityDescriptor> CleanUtilitiesById { get; } = new Dictionary<string, ICleanUtilityDescriptor>();
 
     public CleanTestAssemblyData(IEnumerable<ICleanUtilityDescriptor> initializationUtilities)
     {

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestAssemblyData.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestAssemblyData.cs
@@ -7,15 +7,15 @@ using TryAtSoftware.Extensions.Collections;
 
 public class CleanTestAssemblyData
 {
-    public ICleanTestInitializationCollection<ICleanUtilityDescriptor> InitializationUtilities { get; } = new CleanTestInitializationCollection<ICleanUtilityDescriptor>();
-    public IDictionary<Guid, ICleanUtilityDescriptor> InitializationUtilitiesById { get; } = new Dictionary<Guid, ICleanUtilityDescriptor>();
+    public ICleanTestInitializationCollection<ICleanUtilityDescriptor> CleanUtilities { get; } = new CleanTestInitializationCollection<ICleanUtilityDescriptor>();
+    public IDictionary<Guid, ICleanUtilityDescriptor> CleanUtilitiesById { get; } = new Dictionary<Guid, ICleanUtilityDescriptor>();
 
     public CleanTestAssemblyData(IEnumerable<ICleanUtilityDescriptor> initializationUtilities)
     {
         foreach (var initializationUtility in initializationUtilities.OrEmptyIfNull().IgnoreNullValues())
         {
-            this.InitializationUtilities.Register(initializationUtility.Category, initializationUtility);
-            this.InitializationUtilitiesById[initializationUtility.Id] = initializationUtility;
+            this.CleanUtilities.Register(initializationUtility.Category, initializationUtility);
+            this.CleanUtilitiesById[initializationUtility.Id] = initializationUtility;
         }
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
@@ -6,18 +6,15 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using TryAtSoftware.CleanTests.Core.Extensions;
-using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.CleanTests.Core.XUnit.Execution;
 using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using TryAtSoftware.CleanTests.Core.XUnit.Serialization;
-using TryAtSoftware.Extensions.Collections;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 public class CleanTestCase : XunitTestCase, ICleanTestCase
 {
     private CleanTestCaseData? _cleanTestCaseData;
-    private CleanTestAssemblyData? _cleanTestAssemblyData;
 
     public CleanTestCaseData CleanTestCaseData
     {
@@ -29,16 +26,6 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
         private set => this._cleanTestCaseData = value;
     }
 
-    public CleanTestAssemblyData CleanTestAssemblyData
-    {
-        get
-        {
-            this._cleanTestAssemblyData.ValidateInstantiated("clean test assembly data");
-            return this._cleanTestAssemblyData;
-        }
-        private set => this._cleanTestAssemblyData = value;
-    }
-
 #pragma warning disable CS0618
     public CleanTestCase()
     {
@@ -48,7 +35,6 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
     public CleanTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments, CleanTestAssemblyData cleanTestAssemblyData, CleanTestCaseData cleanTestData)
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
     {
-        this.CleanTestAssemblyData = cleanTestAssemblyData ?? throw new ArgumentNullException(nameof(cleanTestAssemblyData));
         this.CleanTestCaseData = cleanTestData ?? throw new ArgumentNullException(nameof(cleanTestData));
     }
 
@@ -63,16 +49,15 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
     {
         base.Initialize();
 
-        foreach (var initializationUtilityDependencyNode in this.CleanTestCaseData.InitializationUtilities)
+        /*foreach (var initializationUtilityDependencyNode in this.CleanTestCaseData.InitializationUtilities)
         {
-            var initializationUtility = this.GetInitializationUtilityById(initializationUtilityDependencyNode.Id);
-            var category = initializationUtility.Category;
+            var category = initializationUtilityDependencyNode.Category;
             var categories = this.Traits.EnsureValue("Category");
             categories.Add(category);
 
             var initializationUtilities = this.Traits.EnsureValue(category);
-            initializationUtilities.Add(this.IterateDependencyNode(initializationUtilityDependencyNode, x => x.DisplayName));
-        }
+            initializationUtilities.Add(initializationUtilityDependencyNode.DisplayName);
+        }*/
     }
 
     public override void Serialize(IXunitSerializationInfo data)
@@ -81,9 +66,6 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
         
         var testCaseDataSerializer = new SerializableCleanTestCaseData(this.CleanTestCaseData);
         data.AddValue("ctd", testCaseDataSerializer);
-
-        var assemblyDataSerializer = new SerializableCleanTestAssemblyData(this.CleanTestAssemblyData);
-        data.AddValue("ad", assemblyDataSerializer);
     }
 
     public override void Deserialize(IXunitSerializationInfo data)
@@ -91,9 +73,6 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
         var deserializedCleanTestData = data.GetValue<SerializableCleanTestCaseData>("ctd");
         this.CleanTestCaseData = deserializedCleanTestData.CleanTestData;
         
-        var deserializedAssemblyData = data.GetValue<SerializableCleanTestAssemblyData>("ad");
-        this.CleanTestAssemblyData = deserializedAssemblyData.CleanTestData;
-
         base.Deserialize(data);
     }
 
@@ -103,17 +82,14 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
 
         var cleanIdBuilder = new StringBuilder();
         foreach (var initializationUtility in this.CleanTestCaseData.InitializationUtilities)
-            cleanIdBuilder.Append(this.IterateDependencyNode(initializationUtility, x => x.Id.ToString()));
+            cleanIdBuilder.Append(this.IterateDependencyNode(initializationUtility, x => x.Id));
 
         return defaultId + cleanIdBuilder;
     }
 
-    private ICleanUtilityDescriptor GetInitializationUtilityById(Guid id) => this.CleanTestAssemblyData.CleanUtilitiesById[id];
-
-    private string IterateDependencyNode(IndividualInitializationUtilityDependencyNode node, Func<ICleanUtilityDescriptor, string> propertySelector)
+    private string IterateDependencyNode(IndividualInitializationUtilityDependencyNode node, Func<IndividualInitializationUtilityDependencyNode, string> propertySelector)
     {
-        var initializationUtility = this.GetInitializationUtilityById(node.Id);
-        var value = propertySelector(initializationUtility);
+        var value = propertySelector(node);
         if (node.Dependencies.Count == 0) return value;
         return $"{value} ({string.Join(", ", node.Dependencies.Select(x => this.IterateDependencyNode(x, propertySelector)))})";
     }

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
@@ -46,21 +46,6 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
         return runner.RunAsync();
     }
 
-    protected override void Initialize()
-    {
-        base.Initialize();
-
-        /*foreach (var initializationUtilityDependencyNode in this.CleanTestCaseData.InitializationUtilities)
-        {
-            var category = initializationUtilityDependencyNode.Category;
-            var categories = this.Traits.EnsureValue("Category");
-            categories.Add(category);
-
-            var initializationUtilities = this.Traits.EnsureValue(category);
-            initializationUtilities.Add(initializationUtilityDependencyNode.DisplayName);
-        }*/
-    }
-
     public override void Serialize(IXunitSerializationInfo data)
     {
         base.Serialize(data);

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TryAtSoftware.CleanTests.Core.Extensions;
 using TryAtSoftware.CleanTests.Core.XUnit.Execution;
+using TryAtSoftware.CleanTests.Core.XUnit.Extensions;
 using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using TryAtSoftware.CleanTests.Core.XUnit.Serialization;
 using Xunit.Abstractions;
@@ -81,16 +82,9 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
         var defaultId = base.GetUniqueID();
 
         var cleanIdBuilder = new StringBuilder();
-        foreach (var initializationUtility in this.CleanTestCaseData.InitializationUtilities)
-            cleanIdBuilder.Append(this.IterateDependencyNode(initializationUtility, x => x.Id));
+        foreach (var initializationUtility in this.CleanTestCaseData.CleanUtilities)
+            cleanIdBuilder.Append(initializationUtility.GetUniqueId());
 
         return defaultId + cleanIdBuilder;
-    }
-
-    private string IterateDependencyNode(IndividualInitializationUtilityDependencyNode node, Func<IndividualInitializationUtilityDependencyNode, string> propertySelector)
-    {
-        var value = propertySelector(node);
-        if (node.Dependencies.Count == 0) return value;
-        return $"{value} ({string.Join(", ", node.Dependencies.Select(x => this.IterateDependencyNode(x, propertySelector)))})";
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
@@ -108,7 +108,7 @@ public class CleanTestCase : XunitTestCase, ICleanTestCase
         return defaultId + cleanIdBuilder;
     }
 
-    private ICleanUtilityDescriptor GetInitializationUtilityById(Guid id) => this.CleanTestAssemblyData.InitializationUtilitiesById[id];
+    private ICleanUtilityDescriptor GetInitializationUtilityById(Guid id) => this.CleanTestAssemblyData.CleanUtilitiesById[id];
 
     private string IterateDependencyNode(IndividualInitializationUtilityDependencyNode node, Func<ICleanUtilityDescriptor, string> propertySelector)
     {

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCaseData.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCaseData.cs
@@ -7,11 +7,11 @@ using TryAtSoftware.Extensions.Collections;
 public class CleanTestCaseData
 {
     public IDictionary<Type, Type> GenericTypesMap { get; }
-    public IReadOnlyCollection<IndividualInitializationUtilityDependencyNode> InitializationUtilities { get; }
+    public IReadOnlyCollection<IndividualCleanUtilityDependencyNode> CleanUtilities { get; }
 
-    public CleanTestCaseData(IDictionary<Type, Type>? genericTypesMap, IEnumerable<IndividualInitializationUtilityDependencyNode>? initializationUtilities)
+    public CleanTestCaseData(IDictionary<Type, Type>? genericTypesMap, IEnumerable<IndividualCleanUtilityDependencyNode>? cleanUtilities)
     {
         this.GenericTypesMap = genericTypesMap.OrEmptyIfNull();
-        this.InitializationUtilities = initializationUtilities.OrEmptyIfNull().IgnoreNullValues().AsReadOnlyCollection();
+        this.CleanUtilities = cleanUtilities.OrEmptyIfNull().IgnoreNullValues().AsReadOnlyCollection();
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestFramework.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestFramework.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
 using TryAtSoftware.CleanTests.Core.Attributes;
 using TryAtSoftware.CleanTests.Core.Extensions;
 using TryAtSoftware.CleanTests.Core.Interfaces;
@@ -16,15 +15,12 @@ using Xunit.Sdk;
 
 public class CleanTestFramework : XunitTestFramework
 {
-    private readonly ServiceCollection _globalUtilitiesCollection;
-
     public CleanTestFramework(IMessageSink messageSink)
         : base(messageSink)
     {
-        this._globalUtilitiesCollection = new ServiceCollection();
     }
 
-    protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName) => new CleanTestFrameworkExecutor(assemblyName, this.SourceInformationProvider, this.DiagnosticMessageSink, this.CreateDiscoverer, this._globalUtilitiesCollection);
+    protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName) => new CleanTestFrameworkExecutor(assemblyName, this.SourceInformationProvider, this.DiagnosticMessageSink, this.CreateDiscoverer);
 
     protected override ITestFrameworkDiscoverer CreateDiscoverer(IAssemblyInfo assemblyInfo)
     {
@@ -39,7 +35,7 @@ public class CleanTestFramework : XunitTestFramework
             if (loadedAssembly is not null) RegisterUtilitiesFromAssembly(Reflector.Wrap(loadedAssembly), utilitiesCollection);
         }
         
-        return new CleanTestFrameworkDiscoverer(assemblyInfo, this.SourceInformationProvider, this.DiagnosticMessageSink, utilitiesCollection, this._globalUtilitiesCollection);
+        return new CleanTestFrameworkDiscoverer(assemblyInfo, this.SourceInformationProvider, this.DiagnosticMessageSink, utilitiesCollection);
     }
 
     private static void RegisterUtilitiesFromAssembly(IAssemblyInfo assemblyInfo, ICleanTestInitializationCollection<ICleanUtilityDescriptor> utilitiesCollection)

--- a/TryAtSoftware.CleanTests.Core/XUnit/DependencyNodes.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/DependencyNodes.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 /// <summary>
 /// A record representing a multi-level graph-like data structure representing all combinations of the dependencies required to construct a given initialization utility.
@@ -33,4 +34,25 @@ public record IndividualInitializationUtilityDependencyNode(Guid Id)
 {
     public Guid Id { get; } = Id;
     public List<IndividualInitializationUtilityDependencyNode> Dependencies { get; } = new ();
+
+    public string GetUniqueId()
+    {
+        StringBuilder sb = new ();
+        Iterate(this);
+
+        return sb.ToString();
+
+        void Iterate(IndividualInitializationUtilityDependencyNode node, string? id = null)
+        {
+            var isRoot = id is null;
+            if (isRoot) sb.Append(node.Id);
+            else sb.Append($"{id}: {node.Id}");
+
+            for (var i = 0; i < node.Dependencies.Count; i++)
+            {
+                var dependencyId = isRoot ? $"{i + 1}" : $"{id}.{i + 1}";
+                Iterate(node.Dependencies[i], dependencyId);
+            }
+        }
+    }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/DependencyNodes.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/DependencyNodes.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 /// <summary>
 /// A record representing a multi-level graph-like data structure representing all combinations of the dependencies required to construct a given initialization utility.
@@ -34,25 +33,4 @@ public record IndividualInitializationUtilityDependencyNode(Guid Id)
 {
     public Guid Id { get; } = Id;
     public List<IndividualInitializationUtilityDependencyNode> Dependencies { get; } = new ();
-
-    public string GetUniqueId()
-    {
-        StringBuilder sb = new ();
-        Iterate(this);
-
-        return sb.ToString();
-
-        void Iterate(IndividualInitializationUtilityDependencyNode node, string? id = null)
-        {
-            var isRoot = id is null;
-            if (isRoot) sb.Append(node.Id);
-            else sb.Append($"{id}: {node.Id}");
-
-            for (var i = 0; i < node.Dependencies.Count; i++)
-            {
-                var dependencyId = isRoot ? $"{i + 1}" : $"{id}.{i + 1}";
-                Iterate(node.Dependencies[i], dependencyId);
-            }
-        }
-    }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/DependencyNodes.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/DependencyNodes.cs
@@ -9,10 +9,10 @@ using System.Collections.Generic;
 /// | Service 1A |   | Service 2A |   | Service 3A |         | Service 1A |   | Service 2B |   | Service 3A |
 /// </summary>
 /// <param name="Id">The value that should be set to the <see cref="Id"/> property.</param>
-public record FullInitializationUtilityConstructionGraph(string Id)
+public record FullCleanUtilityConstructionGraph(string Id)
 {
     public string Id { get; } = Id;
-    public List<List<FullInitializationUtilityConstructionGraph>> ConstructionDescriptors { get; } = new ();
+    public List<List<FullCleanUtilityConstructionGraph>> ConstructionDescriptors { get; } = new ();
 }
 
 
@@ -28,8 +28,8 @@ public record FullInitializationUtilityConstructionGraph(string Id)
 /// | Service 1A |   | Service 2B |   | Service 3A |
 /// </summary>
 /// <param name="Id">The value that should be set to the <see cref="Id"/> property.</param>
-public record IndividualInitializationUtilityDependencyNode(string Id)
+public record IndividualCleanUtilityDependencyNode(string Id)
 {
     public string Id { get; } = Id;
-    public List<IndividualInitializationUtilityDependencyNode> Dependencies { get; } = new ();
+    public List<IndividualCleanUtilityDependencyNode> Dependencies { get; } = new ();
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/DependencyNodes.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/DependencyNodes.cs
@@ -1,6 +1,5 @@
 ﻿namespace TryAtSoftware.CleanTests.Core.XUnit;
 
-using System;
 using System.Collections.Generic;
 
 /// <summary>
@@ -10,9 +9,9 @@ using System.Collections.Generic;
 /// | Service 1A |   | Service 2A |   | Service 3A |         | Service 1A |   | Service 2B |   | Service 3A |
 /// </summary>
 /// <param name="Id">The value that should be set to the <see cref="Id"/> property.</param>
-public record FullInitializationUtilityConstructionGraph(Guid Id)
+public record FullInitializationUtilityConstructionGraph(string Id)
 {
-    public Guid Id { get; } = Id;
+    public string Id { get; } = Id;
     public List<List<FullInitializationUtilityConstructionGraph>> ConstructionDescriptors { get; } = new ();
 }
 
@@ -29,8 +28,8 @@ public record FullInitializationUtilityConstructionGraph(Guid Id)
 /// | Service 1A |   | Service 2B |   | Service 3A |
 /// </summary>
 /// <param name="Id">The value that should be set to the <see cref="Id"/> property.</param>
-public record IndividualInitializationUtilityDependencyNode(Guid Id)
+public record IndividualInitializationUtilityDependencyNode(string Id)
 {
-    public Guid Id { get; } = Id;
+    public string Id { get; } = Id;
     public List<IndividualInitializationUtilityDependencyNode> Dependencies { get; } = new ();
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/BaseTestCaseDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/BaseTestCaseDiscoverer.cs
@@ -41,7 +41,7 @@ public abstract class BaseTestCaseDiscoverer : IXunitTestCaseDiscoverer
         foreach (var variation in variations)
         {
             // NOTE: This is not the most optimal solution but it works correctly. When we have a lot of spare time, we may think of optimizing this algorithm.
-            if (!AllDemandsAreFulfilled(variation, this._cleanTestAssemblyData.InitializationUtilitiesById)) continue;
+            if (!AllDemandsAreFulfilled(variation, this._cleanTestAssemblyData.CleanUtilitiesById)) continue;
 
             var (isSuccessful, dependenciesSet) = GetDependencies(variation.Values, this._cleanTestAssemblyData);
             if (!isSuccessful) continue;
@@ -83,7 +83,7 @@ public abstract class BaseTestCaseDiscoverer : IXunitTestCaseDiscoverer
         var dependenciesConstructionGraphs = new List<FullInitializationUtilityConstructionGraph>();
         foreach (var utilityId in utilities)
         {
-            var utility = assemblyData.InitializationUtilitiesById[utilityId];
+            var utility = assemblyData.CleanUtilitiesById[utilityId];
             var (isSuccessful, constructionGraph) = BuildConstructionGraph(utility, assemblyData, new HashSet<Guid>());
             if (!isSuccessful) return (IsSuccessful: false, DependencyNodes: Array.Empty<IndividualInitializationUtilityDependencyNode[]>());
 
@@ -119,7 +119,7 @@ public abstract class BaseTestCaseDiscoverer : IXunitTestCaseDiscoverer
         var dependenciesVariations = variationMachine.GetVariations();
         foreach (var variation in dependenciesVariations)
         {
-            if (!AllDemandsAreFulfilled(variation, assemblyData.InitializationUtilitiesById)) continue;
+            if (!AllDemandsAreFulfilled(variation, assemblyData.CleanUtilitiesById)) continue;
 
             var variationDependenciesConstructionGraphs = variation.Values.Select(x => dependencyGraphsById[x]).ToList(); 
             graph.ConstructionDescriptors.Add(variationDependenciesConstructionGraphs);
@@ -134,7 +134,7 @@ public abstract class BaseTestCaseDiscoverer : IXunitTestCaseDiscoverer
         var currentDependencies = new List<Guid>();
             
         // NOTE: Global utilities can depend on other global utilities only. In future we may want to support local utilities to depend on global utilities as well. However, this is not a priority right now.
-        foreach (var dependentUtility in assemblyData.InitializationUtilities.Get(requirement, localDemands).Where(iu => iu.IsGlobal == utilityDescriptor.IsGlobal))
+        foreach (var dependentUtility in assemblyData.CleanUtilities.Get(requirement, localDemands).Where(iu => iu.IsGlobal == utilityDescriptor.IsGlobal))
         {
             var (isSuccessful, dependentUtilityConstructionGraph) = BuildConstructionGraph(dependentUtility, assemblyData, visited);
             if (isSuccessful && dependentUtilityConstructionGraph is not null)

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanFactTestCaseDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanFactTestCaseDiscoverer.cs
@@ -2,14 +2,13 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.DependencyInjection;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 using Xunit.Abstractions;
 
 public class CleanFactTestCaseDiscoverer : BaseTestCaseDiscoverer
 {
-    public CleanFactTestCaseDiscoverer(IMessageSink diagnosticMessageSink, TestCaseDiscoveryOptions testCaseDiscoveryOptions, ICleanTestInitializationCollection<ICleanUtilityDescriptor> initializationUtilitiesCollection, CleanTestAssemblyData cleanTestAssemblyData, ServiceCollection globalUtilitiesCollection) 
-        : base(diagnosticMessageSink, testCaseDiscoveryOptions, initializationUtilitiesCollection, cleanTestAssemblyData, globalUtilitiesCollection)
+    public CleanFactTestCaseDiscoverer(IMessageSink diagnosticMessageSink, TestCaseDiscoveryOptions testCaseDiscoveryOptions, ICleanTestInitializationCollection<ICleanUtilityDescriptor> initializationUtilitiesCollection, CleanTestAssemblyData cleanTestAssemblyData) 
+        : base(diagnosticMessageSink, testCaseDiscoveryOptions, initializationUtilitiesCollection, cleanTestAssemblyData)
     {
     }
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
@@ -18,17 +18,12 @@ using Xunit.Sdk;
 public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
 {
     private readonly FallbackTestFrameworkDiscoverer _fallbackTestFrameworkDiscoverer;
-
-    private readonly ICleanTestInitializationCollection<ICleanUtilityDescriptor> _utilitiesCollection;
     private readonly CleanTestAssemblyData _cleanTestAssemblyData;
 
-    public CleanTestFrameworkDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider, IMessageSink diagnosticMessageSink, ICleanTestInitializationCollection<ICleanUtilityDescriptor> utilitiesCollection)
+    public CleanTestFrameworkDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider, IMessageSink diagnosticMessageSink, CleanTestAssemblyData assemblyData)
         : base(assemblyInfo, sourceProvider, diagnosticMessageSink)
     {
-        this._utilitiesCollection = utilitiesCollection ?? throw new ArgumentNullException(nameof(utilitiesCollection));
-
-        this._cleanTestAssemblyData = new CleanTestAssemblyData(this._utilitiesCollection.GetAllValues());
-        
+        this._cleanTestAssemblyData = assemblyData ?? throw new ArgumentNullException(nameof(assemblyData));
         this._fallbackTestFrameworkDiscoverer = new FallbackTestFrameworkDiscoverer(assemblyInfo, sourceProvider, diagnosticMessageSink);
         this.DisposalTracker.Add(this._fallbackTestFrameworkDiscoverer);
     }
@@ -116,7 +111,7 @@ public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
         foreach (var category in allRequirementSources.Union())
         {
             var categoryDemands = demands.Get(category);
-            foreach (var initializationUtility in this._utilitiesCollection.Get(category, categoryDemands)) customInitializationUtilitiesCollection.Register(category, initializationUtility);
+            foreach (var initializationUtility in this._cleanTestAssemblyData.InitializationUtilities.Get(category, categoryDemands)) customInitializationUtilitiesCollection.Register(category, initializationUtility);
         }
 
         return customInitializationUtilitiesCollection;

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
@@ -3,7 +3,6 @@ namespace TryAtSoftware.CleanTests.Core.XUnit.Discovery;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
 using TryAtSoftware.CleanTests.Core.Attributes;
 using TryAtSoftware.CleanTests.Core.Extensions;
 using TryAtSoftware.CleanTests.Core.Interfaces;
@@ -21,14 +20,12 @@ public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
     private readonly FallbackTestFrameworkDiscoverer _fallbackTestFrameworkDiscoverer;
 
     private readonly ICleanTestInitializationCollection<ICleanUtilityDescriptor> _utilitiesCollection;
-    private readonly ServiceCollection _globalUtilitiesServiceCollection;
     private readonly CleanTestAssemblyData _cleanTestAssemblyData;
 
-    public CleanTestFrameworkDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider, IMessageSink diagnosticMessageSink, ICleanTestInitializationCollection<ICleanUtilityDescriptor> utilitiesCollection, ServiceCollection globalUtilitiesCollection)
+    public CleanTestFrameworkDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider, IMessageSink diagnosticMessageSink, ICleanTestInitializationCollection<ICleanUtilityDescriptor> utilitiesCollection)
         : base(assemblyInfo, sourceProvider, diagnosticMessageSink)
     {
         this._utilitiesCollection = utilitiesCollection ?? throw new ArgumentNullException(nameof(utilitiesCollection));
-        this._globalUtilitiesServiceCollection = globalUtilitiesCollection ?? throw new ArgumentNullException(nameof(globalUtilitiesCollection));
 
         this._cleanTestAssemblyData = new CleanTestAssemblyData(this._utilitiesCollection.GetAllValues());
         
@@ -97,7 +94,7 @@ public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
         if (testCaseDiscovererType is null) return;
 
         var customInitializationUtilitiesCollection = this.GetInitializationUtilities(methodAttributeContainer, options.GlobalRequirements);
-        var testCaseDiscoverer = Activator.CreateInstance(testCaseDiscovererType, this.DiagnosticMessageSink, options.TestCaseDiscoveryOptions, customInitializationUtilitiesCollection, this._cleanTestAssemblyData, this._globalUtilitiesServiceCollection) as IXunitTestCaseDiscoverer;
+        var testCaseDiscoverer = Activator.CreateInstance(testCaseDiscovererType, this.DiagnosticMessageSink, options.TestCaseDiscoveryOptions, customInitializationUtilitiesCollection, this._cleanTestAssemblyData) as IXunitTestCaseDiscoverer;
 
         if (testCaseDiscoverer is null) return;
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
@@ -111,7 +111,7 @@ public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
         foreach (var category in allRequirementSources.Union())
         {
             var categoryDemands = demands.Get(category);
-            foreach (var initializationUtility in this._cleanTestAssemblyData.InitializationUtilities.Get(category, categoryDemands)) customInitializationUtilitiesCollection.Register(category, initializationUtility);
+            foreach (var initializationUtility in this._cleanTestAssemblyData.CleanUtilities.Get(category, categoryDemands)) customInitializationUtilitiesCollection.Register(category, initializationUtility);
         }
 
         return customInitializationUtilitiesCollection;

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTheoryTestCaseDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTheoryTestCaseDiscoverer.cs
@@ -1,7 +1,6 @@
 ﻿namespace TryAtSoftware.CleanTests.Core.XUnit.Discovery;
 
 using System.Collections.Generic;
-using Microsoft.Extensions.DependencyInjection;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.CleanTests.Core.XUnit.Extensions;
 using Xunit.Abstractions;
@@ -9,8 +8,8 @@ using Xunit.Sdk;
 
 public class CleanTheoryTestCaseDiscoverer : BaseTestCaseDiscoverer
 {
-    public CleanTheoryTestCaseDiscoverer(IMessageSink diagnosticMessageSink, TestCaseDiscoveryOptions testCaseDiscoveryOptions, ICleanTestInitializationCollection<ICleanUtilityDescriptor> initializationUtilitiesCollection, CleanTestAssemblyData cleanTestAssemblyData, ServiceCollection globalUtilitiesCollection) 
-        : base(diagnosticMessageSink, testCaseDiscoveryOptions, initializationUtilitiesCollection, cleanTestAssemblyData, globalUtilitiesCollection)
+    public CleanTheoryTestCaseDiscoverer(IMessageSink diagnosticMessageSink, TestCaseDiscoveryOptions testCaseDiscoveryOptions, ICleanTestInitializationCollection<ICleanUtilityDescriptor> initializationUtilitiesCollection, CleanTestAssemblyData cleanTestAssemblyData) 
+        : base(diagnosticMessageSink, testCaseDiscoveryOptions, initializationUtilitiesCollection, cleanTestAssemblyData)
     {
     }
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestAssemblyRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestAssemblyRunner.cs
@@ -1,5 +1,6 @@
 ﻿namespace TryAtSoftware.CleanTests.Core.XUnit.Execution;
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,14 +9,17 @@ using Xunit.Sdk;
 
 public class CleanTestAssemblyRunner : XunitTestAssemblyRunner
 {
-    public CleanTestAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+    private readonly CleanTestAssemblyData _assemblyData;
+    
+    public CleanTestAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions, CleanTestAssemblyData assemblyData)
         : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
     {
+        this._assemblyData = assemblyData ?? throw new ArgumentNullException(nameof(assemblyData));
     }
 
     protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
     {
-        var collectionRunner = new CleanTestCollectionRunner(testCollection, testCases, this.DiagnosticMessageSink, messageBus, this.TestCaseOrderer, new ExceptionAggregator(this.Aggregator), cancellationTokenSource);
+        var collectionRunner = new CleanTestCollectionRunner(testCollection, testCases, this.DiagnosticMessageSink, messageBus, this.TestCaseOrderer, new ExceptionAggregator(this.Aggregator), cancellationTokenSource, this._assemblyData);
         return collectionRunner.RunAsync();
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestAssemblyRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestAssemblyRunner.cs
@@ -1,10 +1,8 @@
 ﻿namespace TryAtSoftware.CleanTests.Core.XUnit.Execution;
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestAssemblyRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestAssemblyRunner.cs
@@ -10,17 +10,14 @@ using Xunit.Sdk;
 
 public class CleanTestAssemblyRunner : XunitTestAssemblyRunner
 {
-    private readonly ServiceCollection _globalUtilitiesCollection;
-    
-    public CleanTestAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions, ServiceCollection globalUtilitiesCollection)
+    public CleanTestAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
         : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
     {
-        this._globalUtilitiesCollection = globalUtilitiesCollection ?? throw new ArgumentNullException(nameof(globalUtilitiesCollection));
     }
 
     protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
     {
-        var collectionRunner = new CleanTestCollectionRunner(testCollection, testCases, this.DiagnosticMessageSink, messageBus, this.TestCaseOrderer, new ExceptionAggregator(this.Aggregator), cancellationTokenSource, this._globalUtilitiesCollection);
+        var collectionRunner = new CleanTestCollectionRunner(testCollection, testCases, this.DiagnosticMessageSink, messageBus, this.TestCaseOrderer, new ExceptionAggregator(this.Aggregator), cancellationTokenSource);
         return collectionRunner.RunAsync();
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestClassRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestClassRunner.cs
@@ -12,18 +12,21 @@ using Xunit.Sdk;
 public class CleanTestClassRunner : XunitTestClassRunner
 {
     private readonly IGlobalUtilitiesProvider _globalUtilitiesProvider;
+    private readonly CleanTestAssemblyData _assemblyData;
         
-    public CleanTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings, IGlobalUtilitiesProvider globalUtilitiesProvider)
+    public CleanTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings, IGlobalUtilitiesProvider globalUtilitiesProvider, CleanTestAssemblyData assemblyData)
         : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
     {
         this._globalUtilitiesProvider = globalUtilitiesProvider ?? throw new ArgumentNullException(nameof(globalUtilitiesProvider));
+        this._assemblyData = assemblyData ?? throw new ArgumentNullException(nameof(assemblyData));
     }
 
     protected override Task<RunSummary> RunTestMethodAsync(ITestMethod testMethod, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, object[] constructorArguments)
     {
-        var enrichedConstructorArguments = new object[constructorArguments.Length + 1];
+        var enrichedConstructorArguments = new object[constructorArguments.Length + 2];
         enrichedConstructorArguments[0] = this._globalUtilitiesProvider;
-        Array.Copy(constructorArguments, 0, enrichedConstructorArguments, 1, constructorArguments.Length);
+        enrichedConstructorArguments[1] = this._assemblyData;
+        Array.Copy(constructorArguments, 0, enrichedConstructorArguments, 2, constructorArguments.Length);
             
         var methodRunner = new CleanTestMethodRunner(testMethod, this.Class, method, testCases, this.DiagnosticMessageSink, this.MessageBus, new ExceptionAggregator(this.Aggregator), this.CancellationTokenSource, enrichedConstructorArguments);
         return methodRunner.RunAsync();

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestClassRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestClassRunner.cs
@@ -5,15 +5,15 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using TryAtSoftware.CleanTests.Core.Utilities;
+using TryAtSoftware.CleanTests.Core.Interfaces;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 public class CleanTestClassRunner : XunitTestClassRunner
 {
-    private readonly GlobalUtilitiesProvider _globalUtilitiesProvider;
+    private readonly IGlobalUtilitiesProvider _globalUtilitiesProvider;
         
-    public CleanTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings, GlobalUtilitiesProvider globalUtilitiesProvider)
+    public CleanTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings, IGlobalUtilitiesProvider globalUtilitiesProvider)
         : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
     {
         this._globalUtilitiesProvider = globalUtilitiesProvider ?? throw new ArgumentNullException(nameof(globalUtilitiesProvider));

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestClassRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestClassRunner.cs
@@ -5,14 +5,15 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using TryAtSoftware.CleanTests.Core.Utilities;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 public class CleanTestClassRunner : XunitTestClassRunner
 {
-    private readonly IServiceProvider _globalUtilitiesProvider;
+    private readonly GlobalUtilitiesProvider _globalUtilitiesProvider;
         
-    public CleanTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings, IServiceProvider globalUtilitiesProvider)
+    public CleanTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings, GlobalUtilitiesProvider globalUtilitiesProvider)
         : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
     {
         this._globalUtilitiesProvider = globalUtilitiesProvider ?? throw new ArgumentNullException(nameof(globalUtilitiesProvider));

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
@@ -1,4 +1,4 @@
-﻿namespace TryAtSoftware.CleanTests.Core.XUnit.Execution;
+namespace TryAtSoftware.CleanTests.Core.XUnit.Execution;
 
 using System;
 using System.Collections.Generic;
@@ -49,8 +49,6 @@ public class CleanTestCollectionRunner : XunitTestCollectionRunner
 
     protected override async Task BeforeTestCollectionFinishedAsync()
     {
-        this._globalUtilitiesProvider.ValidateInstantiated("global utilities provider");
-
         foreach (var globalInitializationUtility in this._globalUtilitiesProvider.GetUtilities<IAsyncLifetime>()) await globalInitializationUtility.DisposeAsync();
         foreach (var globalInitializationUtility in this._globalUtilitiesProvider.GetUtilities<IDisposable>()) this.Aggregator.Run(globalInitializationUtility.Dispose);
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using TryAtSoftware.CleanTests.Core.Extensions;
-using TryAtSoftware.CleanTests.Core.Utilities;
+using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.CleanTests.Core.XUnit.Extensions;
 using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using Xunit;
@@ -14,7 +14,7 @@ using Xunit.Sdk;
 
 public class CleanTestCollectionRunner : XunitTestCollectionRunner
 {
-    private readonly GlobalUtilitiesProvider _globalUtilitiesProvider = new ();
+    private readonly IGlobalUtilitiesProvider _globalUtilitiesProvider = new GlobalUtilitiesProvider();
 
     public CleanTestCollectionRunner(ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
         : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
@@ -61,7 +61,7 @@ public class CleanTestCollectionRunner : XunitTestCollectionRunner
         
         foreach (var dependency in cleanTestCase.CleanTestCaseData.InitializationUtilities)
         {
-            if (!assemblyData.InitializationUtilitiesById.TryGetValue(dependency.Id, out var utilityDescriptor) || utilityDescriptor is not  {IsGlobal:true}) continue;
+            if (!assemblyData.CleanUtilitiesById.TryGetValue(dependency.Id, out var utilityDescriptor) || utilityDescriptor is not  {IsGlobal:true}) continue;
             RegisterGlobalUtility(dependency);
         }
 
@@ -74,14 +74,14 @@ public class CleanTestCollectionRunner : XunitTestCollectionRunner
                 dependencies.Add(subDependencyInstance);
             }
             
-            var (_, implementationType) = dependencyNode.Materialize(cleanTestCase.CleanTestAssemblyData, cleanTestCase.CleanTestCaseData);
-
-            var uniqueId = dependencyNode.GetUniqueId();
-            var registeredInstance = this._globalUtilitiesProvider.GetUtility(uniqueId, implementationType);
+            var uniqueId = dependencyNode.GetUniqueId(cleanTestCase.CleanTestAssemblyData.CleanUtilitiesById, cleanTestCase.CleanTestCaseData.GenericTypesMap);
+            var registeredInstance = this._globalUtilitiesProvider.GetUtility(uniqueId);
             if (registeredInstance is not null) return registeredInstance;
 
+            var (_, implementationType) = dependencyNode.Materialize(cleanTestCase.CleanTestAssemblyData.CleanUtilitiesById, cleanTestCase.CleanTestCaseData.GenericTypesMap);
             var createdInstance = Activator.CreateInstance(implementationType, dependencies.ToArray());
-            this._globalUtilitiesProvider.AddUtility(uniqueId, implementationType, createdInstance);
+
+            this._globalUtilitiesProvider.AddUtility(uniqueId, createdInstance);
             return createdInstance;
         }
     }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
@@ -59,13 +59,13 @@ public class CleanTestCollectionRunner : XunitTestCollectionRunner
 
     private void RegisterGlobalUtilities(ICleanTestCase cleanTestCase)
     {
-        foreach (var dependency in cleanTestCase.CleanTestCaseData.InitializationUtilities)
+        foreach (var dependency in cleanTestCase.CleanTestCaseData.CleanUtilities)
         {
             if (!this._assemblyData.CleanUtilitiesById.TryGetValue(dependency.Id, out var utilityDescriptor) || utilityDescriptor is not  {IsGlobal:true}) continue;
             RegisterGlobalUtility(dependency);
         }
 
-        object RegisterGlobalUtility(IndividualInitializationUtilityDependencyNode dependencyNode)
+        object RegisterGlobalUtility(IndividualCleanUtilityDependencyNode dependencyNode)
         {
             var dependencies = new List<object>(capacity: dependencyNode.Dependencies.Count);
             foreach (var subDependency in dependencyNode.Dependencies)
@@ -74,7 +74,7 @@ public class CleanTestCollectionRunner : XunitTestCollectionRunner
                 dependencies.Add(subDependencyInstance);
             }
             
-            var uniqueId = dependencyNode.GetUniqueId(this._assemblyData.CleanUtilitiesById, cleanTestCase.CleanTestCaseData.GenericTypesMap);
+            var uniqueId = dependencyNode.GetUniqueId();
             var registeredInstance = this._globalUtilitiesProvider.GetUtility(uniqueId);
             if (registeredInstance is not null) return registeredInstance;
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestFrameworkExecutor.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestFrameworkExecutor.cs
@@ -3,27 +3,24 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 public class CleanTestFrameworkExecutor : XunitTestFrameworkExecutor
 {
     private readonly Func<IAssemblyInfo, ITestFrameworkDiscoverer> _createDiscoverer;
-    private readonly ServiceCollection _globalUtilitiesCollection;
 
-    public CleanTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink, Func<IAssemblyInfo, ITestFrameworkDiscoverer> createDiscoverer, ServiceCollection globalUtilitiesCollection)
+    public CleanTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink, Func<IAssemblyInfo, ITestFrameworkDiscoverer> createDiscoverer)
         : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
     {
         this._createDiscoverer = createDiscoverer ?? throw new ArgumentNullException(nameof(createDiscoverer));
-        this._globalUtilitiesCollection = globalUtilitiesCollection ?? throw new ArgumentNullException(nameof(globalUtilitiesCollection));
     }
 
     protected override ITestFrameworkDiscoverer CreateDiscoverer() => this._createDiscoverer(this.AssemblyInfo);
 
     protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
     {
-        using var assemblyRunner = new CleanTestAssemblyRunner(this.TestAssembly, testCases, this.DiagnosticMessageSink, executionMessageSink, executionOptions, this._globalUtilitiesCollection);
+        using var assemblyRunner = new CleanTestAssemblyRunner(this.TestAssembly, testCases, this.DiagnosticMessageSink, executionMessageSink, executionOptions);
         await assemblyRunner.RunAsync();
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestFrameworkExecutor.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestFrameworkExecutor.cs
@@ -9,18 +9,20 @@ using Xunit.Sdk;
 public class CleanTestFrameworkExecutor : XunitTestFrameworkExecutor
 {
     private readonly Func<IAssemblyInfo, ITestFrameworkDiscoverer> _createDiscoverer;
+    private readonly CleanTestAssemblyData _assemblyData;
 
-    public CleanTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink, Func<IAssemblyInfo, ITestFrameworkDiscoverer> createDiscoverer)
+    public CleanTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink, Func<IAssemblyInfo, ITestFrameworkDiscoverer> createDiscoverer, CleanTestAssemblyData assemblyData)
         : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
     {
         this._createDiscoverer = createDiscoverer ?? throw new ArgumentNullException(nameof(createDiscoverer));
+        this._assemblyData = assemblyData ?? throw new ArgumentNullException(nameof(assemblyData));
     }
 
     protected override ITestFrameworkDiscoverer CreateDiscoverer() => this._createDiscoverer(this.AssemblyInfo);
 
     protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
     {
-        using var assemblyRunner = new CleanTestAssemblyRunner(this.TestAssembly, testCases, this.DiagnosticMessageSink, executionMessageSink, executionOptions);
+        using var assemblyRunner = new CleanTestAssemblyRunner(this.TestAssembly, testCases, this.DiagnosticMessageSink, executionMessageSink, executionOptions, this._assemblyData);
         await assemblyRunner.RunAsync();
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using TryAtSoftware.CleanTests.Core.Interfaces;
-using TryAtSoftware.CleanTests.Core.Utilities;
 using TryAtSoftware.CleanTests.Core.XUnit.Extensions;
 using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using TryAtSoftware.Extensions.Collections;
@@ -23,7 +22,7 @@ public class CleanTestInvoker : TestInvoker<ICleanTestCase>
 
     protected override object CreateTestClass()
     {
-        if (this.ConstructorArguments[0] is not GlobalUtilitiesProvider globalUtilitiesProvider) throw new InvalidOperationException("The first constructor argument should be the service provider for global utilities.");
+        if (this.ConstructorArguments[0] is not IGlobalUtilitiesProvider globalUtilitiesProvider) throw new InvalidOperationException("The first constructor argument should be the provider for global utilities.");
         
         var sanitizedConstructorArguments = new object[this.ConstructorArguments.Length - 1];
         Array.Copy(this.ConstructorArguments, 1, sanitizedConstructorArguments, 0, sanitizedConstructorArguments.Length);

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
@@ -40,7 +40,7 @@ public class CleanTestInvoker : TestInvoker<ICleanTestCase>
                 foreach (var implementedInterfaceType in implementedInterfaceTypes) cleanTest.GlobalDependenciesCollection.AddSingleton(implementedInterfaceType, globalUtility);
             }
             else
-                foreach (var implementedInterfaceType in implementationType.GetInterfaces()) cleanTest.LocalDependenciesCollection.AddScoped(implementedInterfaceType, sp => this.ConstructInitializationUtility(dependencyNode, sp));
+                foreach (var implementedInterfaceType in implementedInterfaceTypes) cleanTest.LocalDependenciesCollection.AddScoped(implementedInterfaceType, sp => this.ConstructInitializationUtility(dependencyNode, sp));
         }
 
         return instance;

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
@@ -33,12 +33,13 @@ public class CleanTestInvoker : TestInvoker<ICleanTestCase>
 
         foreach (var dependencyNode in this.TestCase.CleanTestCaseData.InitializationUtilities.OrEmptyIfNull())
         {
-            var (initializationUtility, implementationType) = dependencyNode.Materialize(this.TestCase.CleanTestAssemblyData, this.TestCase.CleanTestCaseData);
+            var (initializationUtility, implementationType) = dependencyNode.Materialize(this.TestCase.CleanTestAssemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
             var implementedInterfaceTypes = implementationType.GetInterfaces();
 
             if (initializationUtility.IsGlobal)
             {
-                var globalUtility = globalUtilitiesProvider.GetUtility(dependencyNode.GetUniqueId(), implementationType);
+                var uniqueId = dependencyNode.GetUniqueId(this.TestCase.CleanTestAssemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
+                var globalUtility = globalUtilitiesProvider.GetUtility(uniqueId);
                 if (globalUtility is null) throw new InvalidOperationException($"Global utility of type {TypeNames.Get(implementationType)} could not be constructed successfully.");
                 foreach (var implementedInterfaceType in implementedInterfaceTypes) cleanTest.GlobalDependenciesCollection.AddSingleton(implementedInterfaceType, globalUtility);
             }
@@ -51,7 +52,7 @@ public class CleanTestInvoker : TestInvoker<ICleanTestCase>
 
     private object ConstructInitializationUtility(IndividualInitializationUtilityDependencyNode dependencyNode, IServiceProvider serviceProvider)
     {
-        var (_, implementationType) = dependencyNode.Materialize(this.TestCase.CleanTestAssemblyData, this.TestCase.CleanTestCaseData);
+        var (_, implementationType) = dependencyNode.Materialize(this.TestCase.CleanTestAssemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
         var dependencies = dependencyNode.Dependencies.Select(dependentUtility => this.ConstructInitializationUtility(dependentUtility, serviceProvider));
         return ActivatorUtilities.CreateInstance(serviceProvider, implementationType, dependencies.ToArray());
     }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
@@ -23,36 +23,37 @@ public class CleanTestInvoker : TestInvoker<ICleanTestCase>
     protected override object CreateTestClass()
     {
         if (this.ConstructorArguments[0] is not IGlobalUtilitiesProvider globalUtilitiesProvider) throw new InvalidOperationException("The first constructor argument should be the provider for global utilities.");
+        if (this.ConstructorArguments[1] is not CleanTestAssemblyData assemblyData) throw new InvalidOperationException("The second constructor argument should be the assembly data for the current test run.");
         
-        var sanitizedConstructorArguments = new object[this.ConstructorArguments.Length - 1];
-        Array.Copy(this.ConstructorArguments, 1, sanitizedConstructorArguments, 0, sanitizedConstructorArguments.Length);
+        var sanitizedConstructorArguments = new object[this.ConstructorArguments.Length - 2];
+        Array.Copy(this.ConstructorArguments, 2, sanitizedConstructorArguments, 0, sanitizedConstructorArguments.Length);
         
         var instance = this.Test.CreateTestClass(this.TestClass, sanitizedConstructorArguments, this.MessageBus, this.Timer, this.CancellationTokenSource);
         if (instance is not ICleanTest cleanTest) return instance;
 
         foreach (var dependencyNode in this.TestCase.CleanTestCaseData.InitializationUtilities.OrEmptyIfNull())
         {
-            var (initializationUtility, implementationType) = dependencyNode.Materialize(this.TestCase.CleanTestAssemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
+            var (initializationUtility, implementationType) = dependencyNode.Materialize(assemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
             var implementedInterfaceTypes = implementationType.GetInterfaces();
 
             if (initializationUtility.IsGlobal)
             {
-                var uniqueId = dependencyNode.GetUniqueId(this.TestCase.CleanTestAssemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
+                var uniqueId = dependencyNode.GetUniqueId(assemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
                 var globalUtility = globalUtilitiesProvider.GetUtility(uniqueId);
                 if (globalUtility is null) throw new InvalidOperationException($"Global utility of type {TypeNames.Get(implementationType)} could not be constructed successfully.");
                 foreach (var implementedInterfaceType in implementedInterfaceTypes) cleanTest.GlobalDependenciesCollection.AddSingleton(implementedInterfaceType, globalUtility);
             }
             else
-                foreach (var implementedInterfaceType in implementedInterfaceTypes) cleanTest.LocalDependenciesCollection.AddScoped(implementedInterfaceType, sp => this.ConstructInitializationUtility(dependencyNode, sp));
+                foreach (var implementedInterfaceType in implementedInterfaceTypes) cleanTest.LocalDependenciesCollection.AddScoped(implementedInterfaceType, sp => this.ConstructInitializationUtility(dependencyNode, assemblyData, sp));
         }
 
         return instance;
     }
 
-    private object ConstructInitializationUtility(IndividualInitializationUtilityDependencyNode dependencyNode, IServiceProvider serviceProvider)
+    private object ConstructInitializationUtility(IndividualInitializationUtilityDependencyNode dependencyNode, CleanTestAssemblyData assemblyData, IServiceProvider serviceProvider)
     {
-        var (_, implementationType) = dependencyNode.Materialize(this.TestCase.CleanTestAssemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
-        var dependencies = dependencyNode.Dependencies.Select(dependentUtility => this.ConstructInitializationUtility(dependentUtility, serviceProvider));
+        var (_, implementationType) = dependencyNode.Materialize(assemblyData.CleanUtilitiesById, this.TestCase.CleanTestCaseData.GenericTypesMap);
+        var dependencies = dependencyNode.Dependencies.Select(dependentUtility => this.ConstructInitializationUtility(dependentUtility, assemblyData, serviceProvider));
         return ActivatorUtilities.CreateInstance(serviceProvider, implementationType, dependencies.ToArray());
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Extensions/XUnitFrameworkExtensions.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Extensions/XUnitFrameworkExtensions.cs
@@ -3,8 +3,10 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using TryAtSoftware.Extensions.Collections;
+using TryAtSoftware.Extensions.Reflection;
 using Xunit.Abstractions;
 
 public static class XUnitFrameworkExtensions
@@ -21,5 +23,15 @@ public static class XUnitFrameworkExtensions
 
         attribute = retrievedSingleAttribute;
         return true;
+    }
+    
+    public static (ICleanUtilityDescriptor InitializationUtility, Type ImplementationType) Materialize(this IndividualInitializationUtilityDependencyNode dependencyNode, CleanTestAssemblyData assemblyData, CleanTestCaseData caseData)
+    {
+        var initializationUtility = assemblyData.InitializationUtilitiesById[dependencyNode.Id];
+
+        var genericTypesSetup = initializationUtility.Type.ExtractGenericParametersSetup(caseData.GenericTypesMap);
+        var implementationType = initializationUtility.Type.MakeGenericType(genericTypesSetup);
+
+        return (initializationUtility, implementationType);
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Extensions/XUnitFrameworkExtensions.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Extensions/XUnitFrameworkExtensions.cs
@@ -26,8 +26,8 @@ public static class XUnitFrameworkExtensions
         attribute = retrievedSingleAttribute;
         return true;
     }
-    
-    public static (ICleanUtilityDescriptor InitializationUtility, Type ImplementationType) Materialize(this IndividualInitializationUtilityDependencyNode dependencyNode, IDictionary<string, ICleanUtilityDescriptor> cleanUtilitiesById, IDictionary<Type, Type> genericTypesMap)
+
+    public static (ICleanUtilityDescriptor InitializationUtility, Type ImplementationType) Materialize(this IndividualCleanUtilityDependencyNode dependencyNode, IDictionary<string, ICleanUtilityDescriptor> cleanUtilitiesById, IDictionary<Type, Type> genericTypesMap)
     {
         var initializationUtility = cleanUtilitiesById[dependencyNode.Id];
 
@@ -37,28 +37,10 @@ public static class XUnitFrameworkExtensions
         return (initializationUtility, implementationType);
     }
 
-    public static string GetUniqueId(this IndividualInitializationUtilityDependencyNode dependencyNode, IDictionary<string, ICleanUtilityDescriptor> cleanUtilitiesById, IDictionary<Type, Type> genericTypesMap)
+    public static string GetUniqueId(this IndividualCleanUtilityDependencyNode node)
     {
-        if (dependencyNode is null) throw new ArgumentNullException(nameof(dependencyNode));
-
-        StringBuilder sb = new();
-        Iterate(dependencyNode);
-        return sb.ToString();
-
-        void Iterate(IndividualInitializationUtilityDependencyNode node, string? id = null)
-        {
-            var isRoot = id is null;
-            if (isRoot) sb.Append(node.Id);
-            else sb.Append($"{id}:{node.Id}");
-
-            var (_, implementationType) = node.Materialize(cleanUtilitiesById, genericTypesMap);
-            sb.Append($",{TypeNames.Get(implementationType)}|");
-
-            for (var i = 0; i < node.Dependencies.Count; i++)
-            {
-                var dependencyId = isRoot ? $"{i + 1}" : $"{id}.{i + 1}";
-                Iterate(node.Dependencies[i], dependencyId);
-            }
-        }
+        var value = node.Id;
+        if (node.Dependencies.Count == 0) return value;
+        return $"{value} ({string.Join(", ", node.Dependencies.Select(x => x.GetUniqueId()))})";
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Extensions/XUnitFrameworkExtensions.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Extensions/XUnitFrameworkExtensions.cs
@@ -27,7 +27,7 @@ public static class XUnitFrameworkExtensions
         return true;
     }
     
-    public static (ICleanUtilityDescriptor InitializationUtility, Type ImplementationType) Materialize(this IndividualInitializationUtilityDependencyNode dependencyNode, IDictionary<Guid, ICleanUtilityDescriptor> cleanUtilitiesById, IDictionary<Type, Type> genericTypesMap)
+    public static (ICleanUtilityDescriptor InitializationUtility, Type ImplementationType) Materialize(this IndividualInitializationUtilityDependencyNode dependencyNode, IDictionary<string, ICleanUtilityDescriptor> cleanUtilitiesById, IDictionary<Type, Type> genericTypesMap)
     {
         var initializationUtility = cleanUtilitiesById[dependencyNode.Id];
 
@@ -37,7 +37,7 @@ public static class XUnitFrameworkExtensions
         return (initializationUtility, implementationType);
     }
 
-    public static string GetUniqueId(this IndividualInitializationUtilityDependencyNode dependencyNode, IDictionary<Guid, ICleanUtilityDescriptor> cleanUtilitiesById, IDictionary<Type, Type> genericTypesMap)
+    public static string GetUniqueId(this IndividualInitializationUtilityDependencyNode dependencyNode, IDictionary<string, ICleanUtilityDescriptor> cleanUtilitiesById, IDictionary<Type, Type> genericTypesMap)
     {
         if (dependencyNode is null) throw new ArgumentNullException(nameof(dependencyNode));
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/Interfaces/ICleanTestCase.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Interfaces/ICleanTestCase.cs
@@ -5,5 +5,4 @@ using Xunit.Sdk;
 public interface ICleanTestCase : IXunitTestCase
 {
     CleanTestCaseData CleanTestCaseData { get; }
-    CleanTestAssemblyData CleanTestAssemblyData { get; }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableCleanTestAssemblyData.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableCleanTestAssemblyData.cs
@@ -45,6 +45,6 @@ public class SerializableCleanTestAssemblyData : IXunitSerializable
     {
         if (info is null) throw new ArgumentNullException(nameof(info));
 
-        info.AddValue("iu", this.CleanTestData.InitializationUtilities.GetAllValues().Select(x => new SerializableInitializationUtility(x)).ToArray());
+        info.AddValue("iu", this.CleanTestData.CleanUtilities.GetAllValues().Select(x => new SerializableInitializationUtility(x)).ToArray());
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableCleanTestCaseData.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableCleanTestCaseData.cs
@@ -52,7 +52,7 @@ public class SerializableCleanTestCaseData : IXunitSerializable
         var genericTypes = this.CleanTestData.GenericTypesMap.Select(kvp => new[] { kvp.Key, kvp.Value }).ToArray();
         info.AddValue("gt", genericTypes);
 
-        var serializableDependencyNodes = this.CleanTestData.InitializationUtilities.Select(x => new SerializableIndividualDependencyNode(x)).ToArray();
+        var serializableDependencyNodes = this.CleanTestData.CleanUtilities.Select(x => new SerializableIndividualDependencyNode(x)).ToArray();
         info.AddValue("iu", serializableDependencyNodes);
     }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableIndividualDependencyNode.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableIndividualDependencyNode.cs
@@ -34,7 +34,7 @@ public class SerializableIndividualDependencyNode : IXunitSerializable
     {
         if (info is null) throw new ArgumentNullException(nameof(info));
 
-        var id = Guid.Parse(info.GetValue<string>("id"));
+        var id = info.GetValue<string>("id");
         this.DependencyNode = new IndividualInitializationUtilityDependencyNode(id);
 
         var deserializedDependencies = info.GetValue<SerializableIndividualDependencyNode[]>("d");
@@ -47,7 +47,7 @@ public class SerializableIndividualDependencyNode : IXunitSerializable
     {
         if (info is null) throw new ArgumentNullException(nameof(info));
 
-        info.AddValue("id", this.DependencyNode.Id.ToString());
+        info.AddValue("id", this.DependencyNode.Id);
 
         var serializableDependencies = this.DependencyNode.Dependencies.Select(x => new SerializableIndividualDependencyNode(x)).ToArray();
         info.AddValue("d", serializableDependencies);

--- a/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableIndividualDependencyNode.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableIndividualDependencyNode.cs
@@ -8,9 +8,9 @@ using Xunit.Abstractions;
 
 public class SerializableIndividualDependencyNode : IXunitSerializable
 {
-    private IndividualInitializationUtilityDependencyNode? _dependencyNode;
+    private IndividualCleanUtilityDependencyNode? _dependencyNode;
 
-    public IndividualInitializationUtilityDependencyNode DependencyNode
+    public IndividualCleanUtilityDependencyNode DependencyNode
     {
         get
         {
@@ -24,7 +24,7 @@ public class SerializableIndividualDependencyNode : IXunitSerializable
     {
     }
 
-    public SerializableIndividualDependencyNode(IndividualInitializationUtilityDependencyNode dependencyNode)
+    public SerializableIndividualDependencyNode(IndividualCleanUtilityDependencyNode dependencyNode)
     {
         this.DependencyNode = dependencyNode ?? throw new ArgumentNullException(nameof(dependencyNode));
     }
@@ -35,7 +35,7 @@ public class SerializableIndividualDependencyNode : IXunitSerializable
         if (info is null) throw new ArgumentNullException(nameof(info));
 
         var id = info.GetValue<string>("id");
-        this.DependencyNode = new IndividualInitializationUtilityDependencyNode(id);
+        this.DependencyNode = new IndividualCleanUtilityDependencyNode(id);
 
         var deserializedDependencies = info.GetValue<SerializableIndividualDependencyNode[]>("d");
         foreach (var dependency in deserializedDependencies.OrEmptyIfNull().Select(x => x?.DependencyNode).IgnoreNullValues())

--- a/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableInitializationUtility.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Serialization/SerializableInitializationUtility.cs
@@ -65,7 +65,7 @@ public class SerializableInitializationUtility : IXunitSerializable
         info.AddValue("c", this.CleanUtilityDescriptor.Category);
         info.AddValue("id", this.CleanUtilityDescriptor.Id.ToString());
         info.AddValue("ut", this.CleanUtilityDescriptor.Type);
-        info.AddValue("un", this.CleanUtilityDescriptor.DisplayName);
+        info.AddValue("un", this.CleanUtilityDescriptor.Name);
         info.AddValue("ig", this.CleanUtilityDescriptor.IsGlobal);
 
         info.AddValue("gd", Serialize(this.CleanUtilityDescriptor.ExternalDemands));

--- a/TryAtSoftware.CleanTests.Core/XUnit/Wrappers/CleanTestAssemblyWrapper.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Wrappers/CleanTestAssemblyWrapper.cs
@@ -1,0 +1,37 @@
+﻿namespace TryAtSoftware.CleanTests.Core.XUnit.Wrappers;
+
+using System;
+using TryAtSoftware.CleanTests.Core.Extensions;
+using Xunit.Abstractions;
+
+public class CleanTestAssemblyWrapper : ITestAssembly
+{
+    private ITestAssembly? _wrapped;
+
+    private ITestAssembly Wrapped
+    {
+        get
+        {
+            this._wrapped.ValidateInstantiated("wrapped test assembly");
+            return this._wrapped;
+        }
+        set => this._wrapped = value;
+    }
+
+    public CleanTestAssemblyWrapper()
+    {
+    }
+
+    public CleanTestAssemblyWrapper(CleanTestAssemblyData assemblyData)
+    {
+        this.AssemblyData = assemblyData ?? throw new ArgumentNullException(nameof(assemblyData));
+    }
+
+    public IAssemblyInfo Assembly => this.Wrapped.Assembly;
+    public string ConfigFileName => this.Wrapped.ConfigFileName;
+    public CleanTestAssemblyData? AssemblyData { get; }
+    
+    public void Deserialize(IXunitSerializationInfo info) => this.Wrapped = info.GetValue<ITestAssembly>("w");
+
+    public void Serialize(IXunitSerializationInfo info) => info.AddValue("w", this.Wrapped);
+}

--- a/TryAtSoftware.CleanTests.Sample/GenericTest.cs
+++ b/TryAtSoftware.CleanTests.Sample/GenericTest.cs
@@ -4,7 +4,7 @@ using TryAtSoftware.CleanTests.Core;
 using TryAtSoftware.CleanTests.Core.Attributes;
 using TryAtSoftware.CleanTests.Sample.Attributes;
 using TryAtSoftware.CleanTests.Sample.Utilities;
-using TryAtSoftware.CleanTests.Sample.Utilities.Engines;
+using TryAtSoftware.CleanTests.Sample.Utilities.Animals;
 using Xunit.Abstractions;
 
 [TestSuiteGenericTypeMapping(typeof(NumericAttribute), typeof(int))]
@@ -20,10 +20,18 @@ public class GenericTest<[Numeric] T> : CleanTest
     public void StandardFact() => Assert.Equal(4, 2 + 2);
 
     [CleanFact]
-    [WithRequirements(Categories.Engines)]
+    [WithRequirements(Categories.Animals)]
     public void TestGlobalUtilitiesDistribution()
     {
-        var engine = this.GetGlobalService<IEngine>();
-        Assert.NotNull(engine);
+        var animal = this.GetGlobalService<IAnimal>();
+        Assert.NotNull(animal);
+    }
+    
+    [CleanFact]
+    [WithRequirements(Categories.Zoos)]
+    public void TestGlobalUtilitiesDistributionWithDependencies()
+    {
+        var zoo = this.GetGlobalService<IZoo>();
+        Assert.NotNull(zoo);
     }
 }

--- a/TryAtSoftware.CleanTests.Sample/GenericTest.cs
+++ b/TryAtSoftware.CleanTests.Sample/GenericTest.cs
@@ -1,8 +1,10 @@
-﻿namespace TryAtSoftware.CleanTests.Sample;
+namespace TryAtSoftware.CleanTests.Sample;
 
 using TryAtSoftware.CleanTests.Core;
 using TryAtSoftware.CleanTests.Core.Attributes;
 using TryAtSoftware.CleanTests.Sample.Attributes;
+using TryAtSoftware.CleanTests.Sample.Utilities;
+using TryAtSoftware.CleanTests.Sample.Utilities.Engines;
 using Xunit.Abstractions;
 
 [TestSuiteGenericTypeMapping(typeof(NumericAttribute), typeof(int))]
@@ -16,4 +18,12 @@ public class GenericTest<[Numeric] T> : CleanTest
 
     [CleanFact]
     public void StandardFact() => Assert.Equal(4, 2 + 2);
+
+    [CleanFact]
+    [WithRequirements(Categories.Engines)]
+    public void TestGlobalUtilitiesDistribution()
+    {
+        var engine = this.GetGlobalService<IEngine>();
+        Assert.NotNull(engine);
+    }
 }

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Animals/Cat.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Animals/Cat.cs
@@ -1,0 +1,10 @@
+﻿namespace TryAtSoftware.CleanTests.Sample.Utilities.Animals;
+
+using TryAtSoftware.CleanTests.Core.Attributes;
+
+[CleanUtility(Categories.Animals, "Cat", IsGlobal = true)]
+public class Cat : IAnimal
+{
+    public string Name => "Tom";
+    public string Phrase => "Meow";
+}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Animals/EmptyZoo.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Animals/EmptyZoo.cs
@@ -1,0 +1,9 @@
+﻿namespace TryAtSoftware.CleanTests.Sample.Utilities.Animals;
+
+using TryAtSoftware.CleanTests.Core.Attributes;
+
+[CleanUtility(Categories.Zoos, "Empty zoo", IsGlobal = true)]
+public class EmptyZoo : IZoo
+{
+    public IEnumerable<IAnimal> GetAnimals() => Enumerable.Empty<IAnimal>();
+}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Animals/IAnimal.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Animals/IAnimal.cs
@@ -1,0 +1,7 @@
+﻿namespace TryAtSoftware.CleanTests.Sample.Utilities.Animals;
+
+public interface IAnimal
+{
+    string Name { get; }
+    string Phrase { get; }
+}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Animals/IZoo.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Animals/IZoo.cs
@@ -1,0 +1,6 @@
+﻿namespace TryAtSoftware.CleanTests.Sample.Utilities.Animals;
+
+public interface IZoo
+{
+    public IEnumerable<IAnimal> GetAnimals();
+}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Animals/Mouse.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Animals/Mouse.cs
@@ -1,0 +1,10 @@
+﻿namespace TryAtSoftware.CleanTests.Sample.Utilities.Animals;
+
+using TryAtSoftware.CleanTests.Core.Attributes;
+
+[CleanUtility(Categories.Animals, "Mouse", IsGlobal = true)]
+public class Mouse : IAnimal
+{
+    public string Name => "Jerry";
+    public string Phrase => "click";
+}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Animals/SingleAnimalZoo.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Animals/SingleAnimalZoo.cs
@@ -1,0 +1,17 @@
+﻿namespace TryAtSoftware.CleanTests.Sample.Utilities.Animals;
+
+using TryAtSoftware.CleanTests.Core.Attributes;
+
+[CleanUtility(Categories.Zoos, "A zoo containing a single animal", IsGlobal = true)]
+[WithRequirements(Categories.Animals)]
+public class SingleAnimalZoo : IZoo
+{
+    private readonly IAnimal _animal;
+
+    public SingleAnimalZoo(IAnimal animal)
+    {
+        this._animal = animal ?? throw new ArgumentNullException(nameof(animal));
+    }
+
+    public IEnumerable<IAnimal> GetAnimals() => new[] { this._animal };
+}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Categories.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Categories.cs
@@ -1,8 +1,9 @@
-namespace TryAtSoftware.CleanTests.Sample.Utilities;
+﻿namespace TryAtSoftware.CleanTests.Sample.Utilities;
 
 public class Categories
 {
     public const string People = "people";
     public const string Creations = "creations";
-    public const string Engines = "engines";
+    public const string Zoos = "zoos";
+    public const string Animals = "animals";
 }

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Categories.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Categories.cs
@@ -1,7 +1,8 @@
-﻿namespace TryAtSoftware.CleanTests.Sample.Utilities;
+namespace TryAtSoftware.CleanTests.Sample.Utilities;
 
 public class Categories
 {
     public const string People = "people";
     public const string Creations = "creations";
+    public const string Engines = "engines";
 }

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Engines/FakeEngine.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Engines/FakeEngine.cs
@@ -1,0 +1,9 @@
+namespace TryAtSoftware.CleanTests.Sample.Utilities.Engines;
+
+using TryAtSoftware.CleanTests.Core.Attributes;
+
+[CleanUtility(Categories.Engines, "Fake engine", IsGlobal = true)]
+public class FakeEngine : IEngine
+{
+    public string ReadLine() => "Pre-defined text";
+}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Engines/FakeEngine.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Engines/FakeEngine.cs
@@ -1,9 +1,0 @@
-namespace TryAtSoftware.CleanTests.Sample.Utilities.Engines;
-
-using TryAtSoftware.CleanTests.Core.Attributes;
-
-[CleanUtility(Categories.Engines, "Fake engine", IsGlobal = true)]
-public class FakeEngine : IEngine
-{
-    public string ReadLine() => "Pre-defined text";
-}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Engines/IEngine.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Engines/IEngine.cs
@@ -1,6 +1,0 @@
-namespace TryAtSoftware.CleanTests.Sample.Utilities.Engines;
-
-public interface IEngine
-{
-    string ReadLine();
-}

--- a/TryAtSoftware.CleanTests.Sample/Utilities/Engines/IEngine.cs
+++ b/TryAtSoftware.CleanTests.Sample/Utilities/Engines/IEngine.cs
@@ -1,0 +1,6 @@
+namespace TryAtSoftware.CleanTests.Sample.Utilities.Engines;
+
+public interface IEngine
+{
+    string ReadLine();
+}


### PR DESCRIPTION
Before this PR it was almost impossible to use Clean tests in VS because of the way `xunit.runners.visualstudio` works.
I introduced some improvements that fix this and improve the performance of discovery and execution.
Moreover, added support for executing tests with generic global utilities that have dependencies between each other.