### PR TITLE
Avoiding generic type parameters mapping for types that do not require it

### DIFF
--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
@@ -37,9 +37,13 @@ public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
         var genericTypesMap = ExtractGenericTypesMap(@class);
         var runtimeClass = @class.ToRuntimeType();
 
-        var genericTypesSetup = runtimeClass.ExtractGenericParametersSetup(genericTypesMap);
-        var genericRuntimeClass = runtimeClass.MakeGenericType(genericTypesSetup);
-        var xUnitTypeInfo = Reflector.Wrap(genericRuntimeClass);
+        if (genericTypesMap.Count > 0)
+        {
+            var genericTypesSetup = runtimeClass.ExtractGenericParametersSetup(genericTypesMap);
+            runtimeClass = runtimeClass.MakeGenericType(genericTypesSetup);
+        }
+
+        var xUnitTypeInfo = Reflector.Wrap(runtimeClass);
 
         // 2. We can beautify the name of the test class.
         // Before: MetadataColoringCleanTests`1[[System.Int64, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]

--- a/TryAtSoftware.CleanTests.Sample/Helpers.cs
+++ b/TryAtSoftware.CleanTests.Sample/Helpers.cs
@@ -1,0 +1,11 @@
+﻿namespace TryAtSoftware.CleanTests.Sample;
+
+// NOTE: We declare these classes to verify that their existence does not affect the way clean tests will be generated.
+
+public class NonGenericHelper
+{
+}
+
+public class GenericHelper<TKey, TValue> 
+{
+}


### PR DESCRIPTION
The generic parameters of a type should be mapped only if the type is decorated with the `TestSuiteGenericTypeMappingAttribute`.