### PR TITLE
Enabled optional access to global utilities

### DIFF
--- a/TryAtSoftware.CleanTests.Core/CleanTest.cs
+++ b/TryAtSoftware.CleanTests.Core/CleanTest.cs
@@ -54,6 +54,12 @@ public abstract class CleanTest : ICleanTest, IDisposable, IAsyncLifetime
         this._scope = this._localDependenciesProvider.CreateScope();
     }
 
+    protected TService? GetOptionalGlobalService<TService>()
+    {
+        Assert.NotNull(this._globalDependenciesProvider);
+        return this._globalDependenciesProvider.GetService<TService>();
+    }
+
     protected TService GetGlobalService<TService>()
         where TService : notnull
     {

--- a/TryAtSoftware.CleanTests.Sample/GenericTest.cs
+++ b/TryAtSoftware.CleanTests.Sample/GenericTest.cs
@@ -34,4 +34,13 @@ public class GenericTest<[Numeric] T> : CleanTest
         var zoo = this.GetGlobalService<IZoo>();
         Assert.NotNull(zoo);
     }
+
+    [CleanFact]
+    public void TestOptionalGlobalServiceAccessor()
+    {
+        var animal = this.GetOptionalGlobalService<IAnimal>();
+        var zoo = this.GetOptionalGlobalService<IZoo>();
+        Assert.Null(animal);
+        Assert.Null(zoo);
+    }
 }


### PR DESCRIPTION
In some cases a global utility may or may not be registered. We need to be able to handle such situations when inheriting the base `CleanTest` class.