### PR TITLE
Combination generation optimizations

### DIFF
--- a/Tests/TryAtSoftware.CleanTests.Benchmark/CombinatorialMachineBenchmark.cs
+++ b/Tests/TryAtSoftware.CleanTests.Benchmark/CombinatorialMachineBenchmark.cs
@@ -7,14 +7,15 @@ using TryAtSoftware.CleanTests.UnitTests.Parametrization;
 
 /*
 28/03/2023:
-|                  Method |    Setup |          Mean |        Error |       StdDev |        Median |
-|------------------------ |--------- |--------------:|-------------:|-------------:|--------------:|
-| GenerateAllCombinations | Setup #1 |      29.30 us |     0.495 us |     0.989 us |      28.87 us |
-| GenerateAllCombinations | Setup #2 |      12.66 us |     0.115 us |     0.108 us |      12.67 us |
-| GenerateAllCombinations | Setup #3 | 217,844.91 us | 4,274.928 us | 8,337.918 us | 218,002.67 us |
-| GenerateAllCombinations | Setup #4 | 195,762.60 us | 3,861.216 us | 6,011.449 us | 195,647.20 us |
-| GenerateAllCombinations | Setup #5 | 325,507.60 us | 6,469.168 us | 7,449.904 us | 325,091.15 us |
-| GenerateAllCombinations | Setup #6 |   1,303.72 us |    16.524 us |    13.798 us |   1,304.00 us |
+|                  Method |    Setup |          Mean |        Error |       StdDev |
+|------------------------ |--------- |--------------:|-------------:|-------------:|
+| GenerateAllCombinations | Setup #1 |      30.10 us |     0.210 us |     0.196 us |
+| GenerateAllCombinations | Setup #2 |      16.93 us |     0.138 us |     0.129 us |
+| GenerateAllCombinations | Setup #3 | 172,957.46 us | 2,525.541 us | 2,238.826 us |
+| GenerateAllCombinations | Setup #4 | 169,320.36 us | 2,768.573 us | 2,589.725 us |
+| GenerateAllCombinations | Setup #5 | 310,245.02 us | 5,375.505 us | 5,028.251 us |
+| GenerateAllCombinations | Setup #6 |   7,992.88 us |    70.567 us |    66.009 us |
+| GenerateAllCombinations | Setup #7 | 113,752.86 us | 2,183.336 us | 2,336.145 us |
  */
 public class CombinatorialMachineBenchmark
 {

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/Parametrization/TestParameters.cs
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/Parametrization/TestParameters.cs
@@ -60,7 +60,11 @@ public static class TestParameters
 
         yield return setup6;
         
-        // TODO: Add a setup for which none of the last level utilities satisfy the first level's demands.
+        // 1000 categories; 100 utilities in each; all utilities in the first category are incompatible with all utilities in the last category.
+        var setup7 = new CombinatorialMachineSetup("Setup #7");
+        for (var i = 0; i < 1000; i++) setup7.WithCategory(ConstructCategoryName(i), 100);
+        for (var i = 1; i <= 100; i++) setup7.WithDemands(ConstructCategoryName(0), i, ConstructCategoryName(999), "q");
+        yield return setup7;
     }
 
     private static string ConstructCategoryName(int letterIndex)

--- a/TryAtSoftware.CleanTests.Core/CleanTestInitializationCollection.cs
+++ b/TryAtSoftware.CleanTests.Core/CleanTestInitializationCollection.cs
@@ -21,6 +21,9 @@ public class CleanTestInitializationCollection<TValue> : ICleanTestInitializatio
     }
 
     /// <inheritdoc />
+    public bool ContainsCategory(string category) => this._data.ContainsKey(category);
+
+    /// <inheritdoc />
     public void Register(string category, TValue value)
     {
         if (value is null) return;

--- a/TryAtSoftware.CleanTests.Core/Interfaces/ICleanTestInitializationCollection.cs
+++ b/TryAtSoftware.CleanTests.Core/Interfaces/ICleanTestInitializationCollection.cs
@@ -6,6 +6,7 @@ public interface ICleanTestInitializationCollection<TValue> : IEnumerable<KeyVal
 {
     IReadOnlyCollection<string> Categories { get; }
     IEnumerable<TValue> Get(string category);
+    bool ContainsCategory(string category);
     void Register(string category, TValue value);
     IEnumerable<TValue> GetAllValues();
 }

--- a/TryAtSoftware.CleanTests.Core/Utilities/CombinatorialMachine.cs
+++ b/TryAtSoftware.CleanTests.Core/Utilities/CombinatorialMachine.cs
@@ -88,15 +88,15 @@ public class CombinatorialMachine
                     Func<ICleanUtilityDescriptor, bool>? predicate = null;
                     if (characteristicsRegister[demandCategory].ContainsKey(demand)) predicate = x => !characteristicsRegister[demandCategory][demand].Contains(x.Id);
 
-                    foreach (var otherUtility in this._utilities.Get(demandCategory).SafeWhere(predicate))
+                    foreach (var incompatibleUtilityId in this._utilities.Get(demandCategory).SafeWhere(predicate).Select(x => x.Id))
                     {
-                        if (incompatibleUtilitiesMap[utility.Id].Add(otherUtility.Id))
+                        if (incompatibleUtilitiesMap[utility.Id].Add(incompatibleUtilityId))
                         {
                             incompatibilityEnforcersByCategory[utility.Category]++;
                             incompatibilityFactorByCategory[utility.Category]++;
                         }
 
-                        if (incompatibleUtilitiesMap[otherUtility.Id].Add(utility.Id)) incompatibilityFactorByCategory[demandCategory]++;
+                        if (incompatibleUtilitiesMap[incompatibleUtilityId].Add(utility.Id)) incompatibilityFactorByCategory[demandCategory]++;
                     }
                 }
             }


### PR DESCRIPTION
Added a method that should extract the incompatible pair of utilities.
Initialization categories are ordered by the sum of enforced incompatibilities and then by the total incompatibility factor.