### PR TITLE
Increased the `TryAtSoftware.CleanTests` package version to 1.1.0-alpha.1

### DIFF
--- a/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
+++ b/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
@@ -8,7 +8,7 @@
         <SonarQubeTestProject>false</SonarQubeTestProject>
 
         <PackageId>TryAtSoftware.CleanTests</PackageId>
-        <Version>1.0.2</Version>
+        <Version>1.1.0-alpha.1</Version>
         <Authors>Tony Troeff</Authors>
         <RepositoryUrl>https://github.com/TryAtSoftware/CleanTests</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This PR will introduce a new pre-release for of `TryAtSoftware.CleanTests` package. The next minor version should introduce some optimizations as well as the `Outer demands` feature.