### PR TITLE
Encapsulate components by restricting their access modifier

### DIFF
--- a/Tests/TryAtSoftware.CleanTests.Benchmark/CombinatorialMachineBenchmark.cs
+++ b/Tests/TryAtSoftware.CleanTests.Benchmark/CombinatorialMachineBenchmark.cs
@@ -21,7 +21,7 @@ using TryAtSoftware.CleanTests.UnitTests.Parametrization;
 | GenerateAllCombinations | Setup #8 |      22.56 us |     0.163 us |     0.153 us |
 | GenerateAllCombinations | Setup #9 |      80.94 us |     0.447 us |     0.396 us |
  */
-public class CombinatorialMachineBenchmark
+internal class CombinatorialMachineBenchmark
 {
     private CombinatorialMachine _machine;
 

--- a/Tests/TryAtSoftware.CleanTests.Benchmark/ConstructionManagerBenchmark.cs
+++ b/Tests/TryAtSoftware.CleanTests.Benchmark/ConstructionManagerBenchmark.cs
@@ -20,7 +20,7 @@ using TryAtSoftware.CleanTests.UnitTests.Parametrization;
 | BuildConstructionGraphs | Setup #6 |     24.91 us |   0.175 us |   0.164 us |    6.0425 |   0.1221 |        - |    49.47 KB |
  */
 [MemoryDiagnoser]
-public class ConstructionManagerBenchmark
+internal class ConstructionManagerBenchmark
 {
     private CleanTestAssemblyData _assemblyData;
 

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/CombinatorialMachineTests.cs
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/CombinatorialMachineTests.cs
@@ -29,7 +29,13 @@ public class CombinatorialMachineTests
         }
     }
 
-    public static IEnumerable<object[]> GetCombinatorialMachineSetups()
-        => TestParameters.ConstructObservableCombinatorialMachineSetups()
-            .Select(combinatorialMachineSetup => new object[] { combinatorialMachineSetup.EnvironmentSetup, combinatorialMachineSetup.ExpectedCombinationsCount });
+    public static TheoryData<EnvironmentSetup, int> GetCombinatorialMachineSetups()
+    {
+        var result = new TheoryData<EnvironmentSetup, int>();
+
+        foreach (var setup in TestParameters.ConstructObservableCombinatorialMachineSetups())
+            result.Add(setup.EnvironmentSetup, setup.ExpectedCombinationsCount);
+        
+        return result;
+    }
 }

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/Extensions/DiscoveryExtensions.cs
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/Extensions/DiscoveryExtensions.cs
@@ -7,12 +7,12 @@ using TryAtSoftware.CleanTests.UnitTests.Mocks;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public static class DiscoveryExtensions
+internal static class DiscoveryExtensions
 {
     private const int DelayBetweenDiscoveryRetries = 50;
     private const int MaxDiscoveryRetries = 20;
     
-    public static async Task<IEnumerable<IXunitTestCase>> DiscoverTestCasesAsync(this IAssemblyInfo assembly, CleanTestAssemblyData assemblyData, TestComponentMocksSuite testComponentMocks)
+    internal static async Task<IEnumerable<IXunitTestCase>> DiscoverTestCasesAsync(this IAssemblyInfo assembly, CleanTestAssemblyData assemblyData, TestComponentMocksSuite testComponentMocks)
     {
         Assert.NotNull(assembly);
         Assert.NotNull(assemblyData);

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/Extensions/ParametrizationExtensions.cs
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/Extensions/ParametrizationExtensions.cs
@@ -4,7 +4,7 @@ using TryAtSoftware.CleanTests.Core.Utilities;
 using TryAtSoftware.CleanTests.Core.XUnit;
 using TryAtSoftware.CleanTests.UnitTests.Parametrization;
 
-public static class ParametrizationExtensions
+internal static class ParametrizationExtensions
 {
     public static CombinatorialMachine MaterializeAsCombinatorialMachine(this EnvironmentSetup environmentSetup)
     {

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/Parametrization/EnvironmentSetup.cs
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/Parametrization/EnvironmentSetup.cs
@@ -26,8 +26,8 @@ public class EnvironmentSetup
         if (string.IsNullOrWhiteSpace(category)) throw new ArgumentNullException(nameof(category));
         if (utilitiesCount <= 0) throw new ArgumentException("The number of utilities for each category must be at least 1", nameof(utilitiesCount));
         
-        if (this._numberOfUtilitiesPerCategory.ContainsKey(category)) throw new InvalidOperationException("Category with that name has already been registered.");
-        this._numberOfUtilitiesPerCategory[category] = utilitiesCount;
+        if (!this._numberOfUtilitiesPerCategory.TryAdd(category, utilitiesCount))
+            throw new InvalidOperationException("Category with that name has already been registered.");
         return this;
     }
 
@@ -77,7 +77,7 @@ public class EnvironmentSetup
         return this;
     }
 
-    public ICleanTestInitializationCollection<ICleanUtilityDescriptor> Materialize()
+    internal ICleanTestInitializationCollection<ICleanUtilityDescriptor> Materialize()
     {
         var utilitiesCollection = new CleanTestInitializationCollection<ICleanUtilityDescriptor>();
 

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/Parametrization/TestParameters.cs
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/Parametrization/TestParameters.cs
@@ -2,7 +2,7 @@
 
 using System.Text;
 
-public static class TestParameters
+internal static class TestParameters
 {
     public static IEnumerable<object?[]> GetInvalidStringParameters()
     {

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/TryAtSoftware.CleanTests.UnitTests.csproj
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/TryAtSoftware.CleanTests.UnitTests.csproj
@@ -10,6 +10,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="TryAtSoftware.CleanTests.Benchmark" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="coverlet.msbuild" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TryAtSoftware.CleanTests.Core/CleanTestInitializationCollection.cs
+++ b/TryAtSoftware.CleanTests.Core/CleanTestInitializationCollection.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.Extensions.Collections;
 
-public class CleanTestInitializationCollection<TValue> : ICleanTestInitializationCollection<TValue>
+internal class CleanTestInitializationCollection<TValue> : ICleanTestInitializationCollection<TValue>
 {
     private readonly IDictionary<string, List<TValue>> _data = new Dictionary<string, List<TValue>>();
 

--- a/TryAtSoftware.CleanTests.Core/CleanUtilityDescriptor.cs
+++ b/TryAtSoftware.CleanTests.Core/CleanUtilityDescriptor.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.Extensions.Collections;
 
-public class CleanUtilityDescriptor : ICleanUtilityDescriptor
+internal class CleanUtilityDescriptor : ICleanUtilityDescriptor
 {
     private readonly HashSet<string> _characteristics = new();
     private readonly HashSet<string> _internalRequirements = new ();

--- a/TryAtSoftware.CleanTests.Core/Construction/ConstructionManager.cs
+++ b/TryAtSoftware.CleanTests.Core/Construction/ConstructionManager.cs
@@ -9,7 +9,7 @@ using TryAtSoftware.CleanTests.Core.Utilities;
 using TryAtSoftware.CleanTests.Core.XUnit;
 using TryAtSoftware.Extensions.Collections;
 
-public class ConstructionManager(CleanTestAssemblyData cleanTestAssemblyData) : IConstructionManager
+internal class ConstructionManager(CleanTestAssemblyData cleanTestAssemblyData) : IConstructionManager
 {
     private readonly CleanTestAssemblyData _cleanTestAssemblyData = cleanTestAssemblyData ?? throw new ArgumentNullException(nameof(cleanTestAssemblyData));
     private readonly Dictionary<string, FullCleanUtilityConstructionGraph?> _constructionGraphsById = new();
@@ -36,12 +36,12 @@ public class ConstructionManager(CleanTestAssemblyData cleanTestAssemblyData) : 
     {
         if (this._constructionGraphsById.TryGetValue(utilityId, out var memoizedResult)) return memoizedResult;
 
-        var graph = this.BuildConstructionGraph(utilityId, new HashSet<string>());
+        var graph = this.BuildConstructionGraph(utilityId, []);
         this._constructionGraphsById[utilityId] = graph;
         return graph;
     }
 
-    private FullCleanUtilityConstructionGraph? BuildConstructionGraph(string utilityId, ISet<string> usedUtilities)
+    private FullCleanUtilityConstructionGraph? BuildConstructionGraph(string utilityId, HashSet<string> usedUtilities)
     {
         var utility = this._cleanTestAssemblyData.CleanUtilitiesById[utilityId];
         var graph = new FullCleanUtilityConstructionGraph(utilityId);
@@ -142,7 +142,7 @@ public class ConstructionManager(CleanTestAssemblyData cleanTestAssemblyData) : 
         }
     }
 
-    private void ExtractDependencies(ICleanUtilityDescriptor utilityDescriptor, string requirement, ISet<string> usedUtilities, ICleanTestInitializationCollection<ICleanUtilityDescriptor> dependenciesCollection, IDictionary<string, FullCleanUtilityConstructionGraph> dependencyGraphsById)
+    private void ExtractDependencies(ICleanUtilityDescriptor utilityDescriptor, string requirement, HashSet<string> usedUtilities, CleanTestInitializationCollection<ICleanUtilityDescriptor> dependenciesCollection, IDictionary<string, FullCleanUtilityConstructionGraph> dependencyGraphsById)
     {
         var localDemands = utilityDescriptor.InternalDemands.Get(requirement);
 

--- a/TryAtSoftware.CleanTests.Core/Construction/FullCleanUtilityConstructionGraph.cs
+++ b/TryAtSoftware.CleanTests.Core/Construction/FullCleanUtilityConstructionGraph.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 /// </summary>
 /// <param name="Id">The value that should be set to the <see cref="Id"/> property.</param>
 /// <remarks>If a full construction graph has no construction descriptors, this means that there are no required dependencies.</remarks>
-public record FullCleanUtilityConstructionGraph(string Id)
+internal record FullCleanUtilityConstructionGraph(string Id)
 {
     public string Id { get; } = Id;
     public List<FullCleanUtilityConstructionGraph[]> ConstructionDescriptors { get; } = new ();

--- a/TryAtSoftware.CleanTests.Core/Construction/IndividualCleanUtilityConstructionGraph.cs
+++ b/TryAtSoftware.CleanTests.Core/Construction/IndividualCleanUtilityConstructionGraph.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 /// | Service 1A |   | Service 2B |   | Service 3A |
 /// </summary>
 /// <param name="Id">The value that should be set to the <see cref="Id"/> property.</param>
-public record IndividualCleanUtilityConstructionGraph(string Id)
+internal record IndividualCleanUtilityConstructionGraph(string Id)
 {
     public string Id { get; } = Id;
     public List<IndividualCleanUtilityConstructionGraph> Dependencies { get; } = new ();

--- a/TryAtSoftware.CleanTests.Core/Extensions/CleanTestsFrameworkExtensions.cs
+++ b/TryAtSoftware.CleanTests.Core/Extensions/CleanTestsFrameworkExtensions.cs
@@ -11,7 +11,7 @@ using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using TryAtSoftware.Extensions.Collections;
 using Xunit.Sdk;
 
-public static class CleanTestsFrameworkExtensions
+internal static class CleanTestsFrameworkExtensions
 {
     public static void CopyTo<T>(this ICleanTestInitializationCollection<T> source, ICleanTestInitializationCollection<T> target)
     {

--- a/TryAtSoftware.CleanTests.Core/Extensions/ConstructionGraphExtensions.cs
+++ b/TryAtSoftware.CleanTests.Core/Extensions/ConstructionGraphExtensions.cs
@@ -2,7 +2,7 @@
 
 using TryAtSoftware.CleanTests.Core.Construction;
 
-public static class ConstructionGraphExtensions
+internal static class ConstructionGraphExtensions
 {
     public static FullCleanUtilityConstructionGraph Copy(this FullCleanUtilityConstructionGraph graph)
     {

--- a/TryAtSoftware.CleanTests.Core/Extensions/StringExtensions.cs
+++ b/TryAtSoftware.CleanTests.Core/Extensions/StringExtensions.cs
@@ -4,5 +4,6 @@ using TryAtSoftware.Extensions.Collections;
 
 internal static class StringExtensions
 {
-    internal static string SurroundWith(this string text, string prefix, string suffix) => string.Join(string.Empty, new[] { prefix, text, suffix }.IgnoreNullOrWhitespaceValues());
+    internal static string SurroundWith(this string text, string prefix, string suffix)
+        => string.Join(string.Empty, new[] { prefix, text, suffix }.IgnoreNullOrWhitespaceValues());
 }

--- a/TryAtSoftware.CleanTests.Core/GlobalUtilitiesProvider.cs
+++ b/TryAtSoftware.CleanTests.Core/GlobalUtilitiesProvider.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 
-public class GlobalUtilitiesProvider : IGlobalUtilitiesProvider
+internal class GlobalUtilitiesProvider : IGlobalUtilitiesProvider
 {
     private readonly Dictionary<string, object> _utilities = new ();
 

--- a/TryAtSoftware.CleanTests.Core/Interfaces/ICleanTestInitializationCollection.cs
+++ b/TryAtSoftware.CleanTests.Core/Interfaces/ICleanTestInitializationCollection.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 
-public interface ICleanTestInitializationCollection<TValue> : IEnumerable<KeyValuePair<string, IEnumerable<TValue>>>
+internal interface ICleanTestInitializationCollection<TValue> : IEnumerable<KeyValuePair<string, IEnumerable<TValue>>>
 {
     IReadOnlyCollection<string> Categories { get; }
     IEnumerable<TValue> Get(string category);

--- a/TryAtSoftware.CleanTests.Core/Interfaces/ICleanUtilityDescriptor.cs
+++ b/TryAtSoftware.CleanTests.Core/Interfaces/ICleanUtilityDescriptor.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-public interface ICleanUtilityDescriptor
+internal interface ICleanUtilityDescriptor
 {
     string Category { get; }
     string Id => $"c:{this.Category}|n:{this.Name}";

--- a/TryAtSoftware.CleanTests.Core/Interfaces/IConstructionManager.cs
+++ b/TryAtSoftware.CleanTests.Core/Interfaces/IConstructionManager.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using TryAtSoftware.CleanTests.Core.Construction;
 
-public interface IConstructionManager
+internal interface IConstructionManager
 {
     IndividualCleanUtilityConstructionGraph[][] BuildIndividualConstructionGraphs(IEnumerable<string> utilityIds);
 }

--- a/TryAtSoftware.CleanTests.Core/Interfaces/IGlobalUtilitiesProvider.cs
+++ b/TryAtSoftware.CleanTests.Core/Interfaces/IGlobalUtilitiesProvider.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 /// <remarks>
 /// The `uniqueId` parameters correspond to the `UniqueId` of an `Individual clean utility dependency node`.
 /// </remarks>
-public interface IGlobalUtilitiesProvider
+internal interface IGlobalUtilitiesProvider
 {
     bool RegisterUtility(string uniqueId, object instance);
     bool IsRegistered(string uniqueId);

--- a/TryAtSoftware.CleanTests.Core/Internal/Validator.cs
+++ b/TryAtSoftware.CleanTests.Core/Internal/Validator.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-public static class Validator
+internal static class Validator
 {
     public static void ValidateMaxDegreeOfParallelism(int value)
     {

--- a/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
+++ b/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
@@ -18,6 +18,11 @@
         <PackageTags>tryatsoftware testing combinatorics</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+    
+    <ItemGroup>
+        <InternalsVisibleTo Include="TryAtSoftware.CleanTests.Benchmark" />
+        <InternalsVisibleTo Include="TryAtSoftware.CleanTests.UnitTests" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="SonarAnalyzer.CSharp" Version="9.29.0.95321">

--- a/TryAtSoftware.CleanTests.Core/Utilities/CombinatorialMachine.cs
+++ b/TryAtSoftware.CleanTests.Core/Utilities/CombinatorialMachine.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.Extensions.Collections;
 
-public class CombinatorialMachine(ICleanTestInitializationCollection<ICleanUtilityDescriptor> utilities)
+internal class CombinatorialMachine(ICleanTestInitializationCollection<ICleanUtilityDescriptor> utilities)
 {
     private readonly ICleanTestInitializationCollection<ICleanUtilityDescriptor> _utilities = utilities ?? throw new ArgumentNullException(nameof(utilities));
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestAssemblyData.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestAssemblyData.cs
@@ -9,7 +9,7 @@ using TryAtSoftware.Extensions.Collections;
 using TryAtSoftware.Extensions.Reflection;
 using TryAtSoftware.Extensions.Reflection.Interfaces;
 
-public class CleanTestAssemblyData
+internal class CleanTestAssemblyData
 {
     private IHierarchyScanner _hierarchyScanner = new HierarchyScanner();
     

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCase.cs
@@ -13,7 +13,7 @@ using TryAtSoftware.Extensions.Collections;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTestCase : XunitTestCase, ICleanTestCase
+internal class CleanTestCase : XunitTestCase, ICleanTestCase
 {
     private CleanTestCaseData? _cleanTestCaseData;
 

--- a/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCaseData.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/CleanTestCaseData.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using TryAtSoftware.CleanTests.Core.Construction;
 using TryAtSoftware.Extensions.Collections;
 
-public class CleanTestCaseData(IDictionary<Type, Type>? genericTypesMap, IEnumerable<IndividualCleanUtilityConstructionGraph>? cleanUtilities, string? displayNamePrefix)
+internal class CleanTestCaseData(IDictionary<Type, Type>? genericTypesMap, IEnumerable<IndividualCleanUtilityConstructionGraph>? cleanUtilities, string? displayNamePrefix)
 {
     public IDictionary<Type, Type> GenericTypesMap { get; } = genericTypesMap.OrEmptyIfNull();
     public IReadOnlyCollection<IndividualCleanUtilityConstructionGraph> CleanUtilities { get; } = cleanUtilities.OrEmptyIfNull().IgnoreNullValues().AsReadOnlyCollection();

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/BaseTestCaseDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/BaseTestCaseDiscoverer.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using TryAtSoftware.CleanTests.Core.Construction;
 using TryAtSoftware.CleanTests.Core.Enums;
@@ -90,15 +89,6 @@ internal abstract class BaseTestCaseDiscoverer(IMessageSink diagnosticMessageSin
 
     private void SetTraits(ITestCase testCase, CleanTestCaseData testData)
     {
-        List<string> lines = [];
-        var cleanUtilities = testData.CleanUtilities.ToArray();
-        for (var i = 0; i < cleanUtilities.Length; i++)
-        {
-            for (var j = i + 1; j < cleanUtilities.Length; j++) lines.Add($"\"{cleanUtilities[i].Id}\",\"{cleanUtilities[j].Id}\",\"sibling\",\"{testCase.UniqueID}\"");
-            foreach (var dependency in cleanUtilities[i].Dependencies) lines.Add($"\"{cleanUtilities[i].Id}\",\"{dependency.Id}\",\"child\",\"{testCase.UniqueID}\"");
-        }
-        File.AppendAllLines("edges.csv", lines);
-
         if ((this._cleanTestAssemblyData.GenericTypeMappingPresentations & CleanTestMetadataPresentations.InTraits) != CleanTestMetadataPresentations.None)
         {
             foreach (var (attributeType, genericParameterType) in testData.GenericTypesMap)

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanFactTestCaseDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanFactTestCaseDiscoverer.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using TryAtSoftware.CleanTests.Core.Interfaces;
 using Xunit.Abstractions;
 
-public class CleanFactTestCaseDiscoverer(IMessageSink diagnosticMessageSink, TestCaseDiscoveryOptions testCaseDiscoveryOptions, ICleanTestInitializationCollection<ICleanUtilityDescriptor> initializationUtilitiesCollection, IConstructionManager constructionManager, CleanTestAssemblyData cleanTestAssemblyData)
+internal class CleanFactTestCaseDiscoverer(IMessageSink diagnosticMessageSink, TestCaseDiscoveryOptions testCaseDiscoveryOptions, ICleanTestInitializationCollection<ICleanUtilityDescriptor> initializationUtilitiesCollection, IConstructionManager constructionManager, CleanTestAssemblyData cleanTestAssemblyData)
     : BaseTestCaseDiscoverer(diagnosticMessageSink, testCaseDiscoveryOptions, initializationUtilitiesCollection, constructionManager, cleanTestAssemblyData)
 {
     protected override IEnumerable<object[]> GetTestMethodArguments(IMessageSink diagnosticMessageSink,

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTestFrameworkDiscoverer.cs
@@ -15,7 +15,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
+internal class CleanTestFrameworkDiscoverer : TestFrameworkDiscoverer
 {
     private readonly FallbackTestFrameworkDiscoverer _fallbackTestFrameworkDiscoverer;
     private readonly CleanTestAssemblyData _cleanTestAssemblyData;

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTheoryTestCaseDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/CleanTheoryTestCaseDiscoverer.cs
@@ -6,7 +6,7 @@ using TryAtSoftware.CleanTests.Core.XUnit.Extensions;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTheoryTestCaseDiscoverer(IMessageSink diagnosticMessageSink, TestCaseDiscoveryOptions testCaseDiscoveryOptions, ICleanTestInitializationCollection<ICleanUtilityDescriptor> initializationUtilitiesCollection, IConstructionManager constructionManager, CleanTestAssemblyData cleanTestAssemblyData)
+internal class CleanTheoryTestCaseDiscoverer(IMessageSink diagnosticMessageSink, TestCaseDiscoveryOptions testCaseDiscoveryOptions, ICleanTestInitializationCollection<ICleanUtilityDescriptor> initializationUtilitiesCollection, IConstructionManager constructionManager, CleanTestAssemblyData cleanTestAssemblyData)
     : BaseTestCaseDiscoverer(diagnosticMessageSink, testCaseDiscoveryOptions, initializationUtilitiesCollection, constructionManager, cleanTestAssemblyData)
 {
     protected override IEnumerable<object[]> GetTestMethodArguments(IMessageSink diagnosticMessageSink, ITestMethod testMethod)

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/FallbackTestFrameworkDiscoverer.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/FallbackTestFrameworkDiscoverer.cs
@@ -3,7 +3,7 @@
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class FallbackTestFrameworkDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider, IMessageSink diagnosticMessageSink, IXunitTestCollectionFactory? collectionFactory = null)
+internal class FallbackTestFrameworkDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider, IMessageSink diagnosticMessageSink, IXunitTestCollectionFactory? collectionFactory = null)
     : XunitTestFrameworkDiscoverer(assemblyInfo, sourceProvider, diagnosticMessageSink, collectionFactory)
 {
     public void DiscoverFallbackTests(ITestMethod testMethod, bool includeSourceInformation, IMessageBus messageBus, ITestFrameworkDiscoveryOptions discoveryOptions)

--- a/TryAtSoftware.CleanTests.Core/XUnit/Discovery/TestCaseDiscoveryOptions.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Discovery/TestCaseDiscoveryOptions.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using TryAtSoftware.Extensions.Collections;
 
-public class TestCaseDiscoveryOptions(IDictionary<Type, Type>? genericTypes = null)
+internal class TestCaseDiscoveryOptions(IDictionary<Type, Type>? genericTypes = null)
 {
     public IDictionary<Type, Type> GenericTypes { get; } = genericTypes.OrEmptyIfNull();
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestAssemblyRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestAssemblyRunner.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTestAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions, CleanTestAssemblyData assemblyData)
+internal class CleanTestAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions, CleanTestAssemblyData assemblyData)
     : XunitTestAssemblyRunner(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
 {
     private readonly CleanTestAssemblyData _assemblyData = assemblyData ?? throw new ArgumentNullException(nameof(assemblyData));

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCaseRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCaseRunner.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using Xunit.Sdk;
 
-public class CleanTestCaseRunner(ICleanTestCase testCase, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, object[] constructorArguments)
+internal class CleanTestCaseRunner(ICleanTestCase testCase, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, object[] constructorArguments)
     : TestCaseRunner<ICleanTestCase>(testCase, messageBus, aggregator, cancellationTokenSource)
 {
     private readonly object[] _constructorArguments = constructorArguments ?? throw new ArgumentNullException(nameof(constructorArguments));

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestClassRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestClassRunner.cs
@@ -9,7 +9,7 @@ using TryAtSoftware.CleanTests.Core.Interfaces;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings, IGlobalUtilitiesProvider globalUtilitiesProvider, CleanTestAssemblyData assemblyData)
+internal class CleanTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings, IGlobalUtilitiesProvider globalUtilitiesProvider, CleanTestAssemblyData assemblyData)
     : XunitTestClassRunner(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
 {
     private readonly IGlobalUtilitiesProvider _globalUtilitiesProvider = globalUtilitiesProvider ?? throw new ArgumentNullException(nameof(globalUtilitiesProvider));

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestCollectionRunner.cs
@@ -15,7 +15,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public sealed class CleanTestCollectionRunner : XunitTestCollectionRunner, IDisposable
+internal sealed class CleanTestCollectionRunner : XunitTestCollectionRunner, IDisposable
 {
     private readonly ServiceProvider _globalServicesProvider;
     private readonly IGlobalUtilitiesProvider _globalUtilitiesProvider = new GlobalUtilitiesProvider();

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestFrameworkExecutor.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestFrameworkExecutor.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink, Func<IAssemblyInfo, ITestFrameworkDiscoverer> createDiscoverer, CleanTestAssemblyData assemblyData)
+internal class CleanTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink, Func<IAssemblyInfo, ITestFrameworkDiscoverer> createDiscoverer, CleanTestAssemblyData assemblyData)
     : XunitTestFrameworkExecutor(assemblyName, sourceInformationProvider, diagnosticMessageSink)
 {
     private readonly Func<IAssemblyInfo, ITestFrameworkDiscoverer> _createDiscoverer = createDiscoverer ?? throw new ArgumentNullException(nameof(createDiscoverer));

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestInvoker.cs
@@ -14,7 +14,7 @@ using TryAtSoftware.Extensions.Reflection;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTestInvoker(ITest test, IMessageBus messageBus, Type testClass, object[] constructorArguments, MethodInfo testMethod, object[] testMethodArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+internal class CleanTestInvoker(ITest test, IMessageBus messageBus, Type testClass, object[] constructorArguments, MethodInfo testMethod, object[] testMethodArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
     : TestInvoker<ICleanTestCase>(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, aggregator, cancellationTokenSource)
 {
     protected override object CreateTestClass()

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestMethodRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestMethodRunner.cs
@@ -10,7 +10,7 @@ using TryAtSoftware.CleanTests.Core.Attributes;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTestMethodRunner(ITestMethod testMethod, IReflectionTypeInfo @class, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, object[] constructorArguments, CleanTestAssemblyData assemblyData)
+internal class CleanTestMethodRunner(ITestMethod testMethod, IReflectionTypeInfo @class, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, object[] constructorArguments, CleanTestAssemblyData assemblyData)
     : XunitTestMethodRunner(testMethod, @class, method, testCases, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource, constructorArguments)
 {
     private readonly CleanTestAssemblyData _assemblyData = assemblyData ?? throw new ArgumentNullException(nameof(assemblyData));

--- a/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestRunner.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Execution/CleanTestRunner.cs
@@ -11,7 +11,7 @@ using TryAtSoftware.CleanTests.Core.XUnit.Interfaces;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-public class CleanTestRunner(ITest test, IMessageBus messageBus, Type testClass, object[] constructorArguments, MethodInfo testMethod, object[] testMethodArguments, string skipReason, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+internal class CleanTestRunner(ITest test, IMessageBus messageBus, Type testClass, object[] constructorArguments, MethodInfo testMethod, object[] testMethodArguments, string skipReason, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
     : TestRunner<ICleanTestCase>(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, aggregator, cancellationTokenSource)
 {
     protected override async Task<Tuple<decimal, string>> InvokeTestAsync(ExceptionAggregator aggregator)

--- a/TryAtSoftware.CleanTests.Core/XUnit/Interfaces/ICleanTestCase.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Interfaces/ICleanTestCase.cs
@@ -2,7 +2,7 @@
 
 using Xunit.Sdk;
 
-public interface ICleanTestCase : IXunitTestCase
+internal interface ICleanTestCase : IXunitTestCase
 {
     CleanTestCaseData CleanTestCaseData { get; }
 }

--- a/TryAtSoftware.CleanTests.Core/XUnit/Interfaces/IDecoratedComponent.cs
+++ b/TryAtSoftware.CleanTests.Core/XUnit/Interfaces/IDecoratedComponent.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using Xunit.Abstractions;
 
-public interface IDecoratedComponent
+internal interface IDecoratedComponent
 {
     IEnumerable<IAttributeInfo> GetCustomAttributes(Type attributeType);
 }

--- a/TryAtSoftware.CleanTests.Sample/GenericTest.cs
+++ b/TryAtSoftware.CleanTests.Sample/GenericTest.cs
@@ -8,14 +8,9 @@ using TryAtSoftware.CleanTests.Sample.Utilities.Animals;
 using Xunit.Abstractions;
 
 [TestSuiteGenericTypeMapping(typeof(NumericAttribute), typeof(int))]
-public class GenericTest<[Numeric] T> : CleanTest
+public class GenericTest<[Numeric] T>(ITestOutputHelper testOutputHelper) : CleanTest(testOutputHelper)
     where T : notnull
 {
-    public GenericTest(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
-    }
-
     [CleanFact]
     public void StandardFact() => Assert.Equal(4, 2 + 2);
 


### PR DESCRIPTION
## Pull Request Description 

There are a lot of publicly exposed components that cannot be easily modified because of breaking changes. In order to resolve this issue, we have decided to restrict their access from public to internal. Tests will still be able to access them, however.

## Checklist

- [x] I have tested these changes thoroughly.
- [ ] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [ ] My changes are backwards compatible.
