### PR TITLE
Extend unit tests for outer demands

### DIFF
--- a/Tests/TryAtSoftware.CleanTests.UnitTests/ConstructionManagerTests.cs
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/ConstructionManagerTests.cs
@@ -11,8 +11,7 @@ using TryAtSoftware.Randomizer.Core.Helpers;
 
 public class ConstructionManagerTests
 {
-    [Theory(Timeout = UnitTestConstants.Timeout)]
-    [MemberData(nameof(GetDependenciesManagerSetups))]
+    [Theory(Timeout = UnitTestConstants.Timeout), MemberData(nameof(GetDependenciesManagerSetups))]
     public Task DependencyGraphsShouldBeConstructedSuccessfully(EnvironmentSetup setup, string pathToExpectedResult)
     {
         var assemblyTestData = setup.MaterializeAsAssemblyData();
@@ -41,32 +40,32 @@ public class ConstructionManagerTests
         
         for (var i = 1; i <= count; i++)
         {
-            setup.WithCharacteristics("Q", i, $"C{i}");
-            setup.WithOuterDemands("N1", i, "Q", $"C{i}");
+            setup.WithCharacteristics("Q", i, $"O{i}");
+            setup.WithOuterDemands("N1", i, "Q", $"O{i}");
         }
 
         var assemblyTestData = setup.MaterializeAsAssemblyData();
         var manager = new ConstructionManager(assemblyTestData);
 
-        var utilitiesMatrix = ExtractUtilitiesForOuterDemandsTesting(assemblyTestData, depth: 1, count);
+        var matrix = ExtractMatrixForOuterDemandsTesting(assemblyTestData, depth: 1, count);
 
         for (var i = 0; i < count; i++)
         {
-            var utilityIds = new[] { utilitiesMatrix[0][0].Id, utilitiesMatrix[^1][i].Id };
+            var utilityIds = new[] { matrix[0][0].Id, matrix[^1][i].Id };
             var constructionGraphs = manager.BuildIndividualConstructionGraphs(utilityIds);
             Assert.Single(constructionGraphs);
             Assert.Equal(2, constructionGraphs[0].Length);
             
             var penultConstructionGraph = constructionGraphs[0][0];
-            Assert.Equal(utilitiesMatrix[0][0].Id, penultConstructionGraph.Id);
+            Assert.Equal(matrix[0][0].Id, penultConstructionGraph.Id);
             Assert.Single(penultConstructionGraph.Dependencies);
         
             var qConstructionGraph = constructionGraphs[0][1];
-            Assert.Equal(utilitiesMatrix[^1][i].Id, qConstructionGraph.Id);
+            Assert.Equal(matrix[^1][i].Id, qConstructionGraph.Id);
             Assert.Empty(qConstructionGraph.Dependencies);
         
             var lastConstructionGraph = penultConstructionGraph.Dependencies[0];
-            Assert.Equal(utilitiesMatrix[1][i].Id, lastConstructionGraph.Id);
+            Assert.Equal(matrix[1][i].Id, lastConstructionGraph.Id);
             Assert.Empty(lastConstructionGraph.Dependencies);
         }
     }
@@ -80,18 +79,18 @@ public class ConstructionManagerTests
 
         for (var i = 1; i <= count; i++)
         {
-            setup.WithCharacteristics("Q", i, $"C{i}");
-            setup.WithOuterDemands("N1", i, "Q", $"D{i}");
+            setup.WithCharacteristics("Q", i, $"O{i}");
+            setup.WithOuterDemands("N1", i, "Q", $"X{i}");
         }
 
         var assemblyTestData = setup.MaterializeAsAssemblyData();
         var manager = new ConstructionManager(assemblyTestData);
 
-        var utilitiesMatrix = ExtractUtilitiesForOuterDemandsTesting(assemblyTestData, depth: 1, count);
+        var matrix = ExtractMatrixForOuterDemandsTesting(assemblyTestData, depth: 1, count);
 
         for (var i = 0; i < count; i++)
         {
-            var utilityIds = new[] { utilitiesMatrix[0][0].Id, utilitiesMatrix[^1][i].Id };
+            var utilityIds = new[] { matrix[0][0].Id, matrix[^1][i].Id };
             var constructionGraphs = manager.BuildIndividualConstructionGraphs(utilityIds);
             Assert.Empty(constructionGraphs);
         }
@@ -106,46 +105,16 @@ public class ConstructionManagerTests
 
         for (var i = 1; i <= count; i++)
         {
-            setup.WithCharacteristics("Q", i, $"C{i}");
-            setup.WithOuterDemands($"N{depth}", i, "Q", $"C{i}");
+            setup.WithCharacteristics("Q", i, $"O{i}");
+            setup.WithOuterDemands($"N{depth}", i, "Q", $"O{i}");
         }
 
         var assemblyTestData = setup.MaterializeAsAssemblyData();
         var manager = new ConstructionManager(assemblyTestData);
 
-        var utilitiesMatrix = ExtractUtilitiesForOuterDemandsTesting(assemblyTestData, depth, count);
-
-        var utilityIds = utilitiesMatrix[0].Select(x => x.Id);
-        var constructionGraphs = manager.BuildIndividualConstructionGraphs(utilityIds);
-        
-        Assert.Equal(count, constructionGraphs.Length);
-        for (var i = 0; i < count; i++)
-        {
-            var analyzedGraph = Assert.Single(constructionGraphs[i]);
-
-            for (var j = 0; j < depth - 2; j++)
-            {
-                Assert.Equal(utilitiesMatrix[j][0].Id, analyzedGraph.Id);
-                Assert.Single(analyzedGraph.Dependencies);
-
-                analyzedGraph = analyzedGraph.Dependencies[0];
-            }
-            
-            Assert.Equal(utilitiesMatrix[depth - 2][0].Id, analyzedGraph.Id);
-            Assert.Equal(2, analyzedGraph.Dependencies.Count);
-        
-            var penultConstructionGraph = analyzedGraph.Dependencies[0];
-            Assert.Equal(utilitiesMatrix[depth - 1][0].Id, penultConstructionGraph.Id);
-            Assert.Single(penultConstructionGraph.Dependencies);
-        
-            var qConstructionGraph = analyzedGraph.Dependencies[1];
-            Assert.Equal(utilitiesMatrix[^1][i].Id, qConstructionGraph.Id);
-            Assert.Empty(qConstructionGraph.Dependencies);
-        
-            var lastConstructionGraph = penultConstructionGraph.Dependencies[0];
-            Assert.Equal(utilitiesMatrix[depth][i].Id, lastConstructionGraph.Id);
-            Assert.Empty(lastConstructionGraph.Dependencies);
-        }
+        var matrix = ExtractMatrixForOuterDemandsTesting(assemblyTestData, depth, count);
+        var constructionGraphs = manager.BuildIndividualConstructionGraphs(matrix[0].Select(x => x.Id));
+        AssertCorrectConstructionWithOuterDemandsAtDeeperLevels(constructionGraphs, matrix, depth, count);
     }
 
     [Theory, MemberData(nameof(GetDepthMembers))]
@@ -157,22 +126,52 @@ public class ConstructionManagerTests
 
         for (var i = 1; i <= count; i++)
         {
-            setup.WithCharacteristics("Q", i, $"C{i}");
-            setup.WithOuterDemands($"N{depth}", i, "Q", $"D{i}");
+            setup.WithCharacteristics("Q", i, $"O{i}");
+            setup.WithOuterDemands($"N{depth}", i, "Q", $"X{i}");
         }
 
         var assemblyTestData = setup.MaterializeAsAssemblyData();
         var manager = new ConstructionManager(assemblyTestData);
 
-        var utilitiesMatrix = ExtractUtilitiesForOuterDemandsTesting(assemblyTestData, depth, count);
-
-        var utilityIds = utilitiesMatrix[0].Select(x => x.Id);
-        var constructionGraphs = manager.BuildIndividualConstructionGraphs(utilityIds);
+        var matrix = ExtractMatrixForOuterDemandsTesting(assemblyTestData, depth, count);
+        var constructionGraphs = manager.BuildIndividualConstructionGraphs(matrix[0].Select(x => x.Id));
         Assert.Empty(constructionGraphs);
     }
 
     /// <summary>
-    /// |N0| -> |N1| -> ... -> |N{depth - 2}| -> |N{depth - 1}| -> |N{depth}|<br/>
+    /// N{depth} defines unsatisfiable outer demands towards N0, N1, ..., N{depth - 2}.
+    /// These unsatisfiable demands do not impact the construction of individual graphs,
+    /// as the referenced utilities are not located within the immediate higher hierarchical level.
+    /// </summary>
+    [Theory, MemberData(nameof(GetDepthMembers))]
+    public void OuterDemandsShouldOnlyTargetTheImmediateHigherLevel(int depth)
+    {
+        var setup = new EnvironmentSetup("outer_demands_env");
+        var count = RandomizationHelper.RandomInteger(3, 10);
+        PrepareForOuterDemandsTesting(setup, depth, count);
+
+        for (var i = 1; i <= count; i++)
+        {
+            setup.WithCharacteristics("Q", i, $"O{i}");
+            setup.WithOuterDemands($"N{depth}", i, "Q", $"O{i}");
+
+            for (var j = 0; j < depth - 1; j++)
+            {
+                setup.WithCharacteristics($"N{j}", 1, $"O{i}");
+                setup.WithOuterDemands($"N{depth}", i, $"N{j}", $"X{i}");
+            }
+        }
+
+        var assemblyTestData = setup.MaterializeAsAssemblyData();
+        var manager = new ConstructionManager(assemblyTestData);
+
+        var matrix = ExtractMatrixForOuterDemandsTesting(assemblyTestData, depth, count);
+        var constructionGraphs = manager.BuildIndividualConstructionGraphs(matrix[0].Select(x => x.Id));
+        AssertCorrectConstructionWithOuterDemandsAtDeeperLevels(constructionGraphs, matrix, depth, count);
+    }
+
+    /// <summary>
+    /// |N0| -> |N1| -> ... -> |N{depth - 2}| -> |N{depth - 1}| -> |N{depth}|
     ///                                       -> |Q| -----------------^
     ///
     /// N{depth} defines outer demands towards Q
@@ -194,7 +193,7 @@ public class ConstructionManagerTests
     /// - The first `depth + 1` entries are reserved for the `N#` categories.
     /// - The last entry is reserved for the `Q` category.
     /// </summary>
-    private static ICleanUtilityDescriptor[][] ExtractUtilitiesForOuterDemandsTesting(CleanTestAssemblyData assemblyTestData, int depth, int count)
+    private static ICleanUtilityDescriptor[][] ExtractMatrixForOuterDemandsTesting(CleanTestAssemblyData assemblyTestData, int depth, int count)
     {
         // NOTE: There are depth + 1 `N#` categories and `Q`.
         var matrix = new ICleanUtilityDescriptor[depth + 2][];
@@ -205,6 +204,38 @@ public class ConstructionManagerTests
         for (var i = depth; i < matrix.Length; i++) Assert.Equal(count, matrix[i].Length);
 
         return matrix;
+    }
+
+    private static void AssertCorrectConstructionWithOuterDemandsAtDeeperLevels(IndividualCleanUtilityConstructionGraph[][] constructionGraphs, ICleanUtilityDescriptor[][] matrix, int depth, int count)
+    {
+        Assert.Equal(count, constructionGraphs.Length);
+        for (var i = 0; i < count; i++)
+        {
+            var analyzedGraph = Assert.Single(constructionGraphs[i]);
+
+            for (var j = 0; j < depth - 2; j++)
+            {
+                Assert.Equal(matrix[j][0].Id, analyzedGraph.Id);
+                Assert.Single(analyzedGraph.Dependencies);
+
+                analyzedGraph = analyzedGraph.Dependencies[0];
+            }
+            
+            Assert.Equal(matrix[depth - 2][0].Id, analyzedGraph.Id);
+            Assert.Equal(2, analyzedGraph.Dependencies.Count);
+        
+            var penultConstructionGraph = analyzedGraph.Dependencies[0];
+            Assert.Equal(matrix[depth - 1][0].Id, penultConstructionGraph.Id);
+            Assert.Single(penultConstructionGraph.Dependencies);
+        
+            var qConstructionGraph = analyzedGraph.Dependencies[1];
+            Assert.Equal(matrix[^1][i].Id, qConstructionGraph.Id);
+            Assert.Empty(qConstructionGraph.Dependencies);
+        
+            var lastConstructionGraph = penultConstructionGraph.Dependencies[0];
+            Assert.Equal(matrix[depth][i].Id, lastConstructionGraph.Id);
+            Assert.Empty(lastConstructionGraph.Dependencies);
+        }
     }
 
     public static TheoryData<EnvironmentSetup, string> GetDependenciesManagerSetups()

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/ConstructionManagerTests.cs
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/ConstructionManagerTests.cs
@@ -2,6 +2,7 @@
 
 using System.Text.Json;
 using TryAtSoftware.CleanTests.Core.Construction;
+using TryAtSoftware.CleanTests.Core.Interfaces;
 using TryAtSoftware.CleanTests.UnitTests.Constants;
 using TryAtSoftware.CleanTests.UnitTests.Extensions;
 using TryAtSoftware.CleanTests.UnitTests.Parametrization;
@@ -113,64 +114,6 @@ public class ConstructionManagerTests
     }
 
     [Fact]
-    public void OuterDemandsShouldBeAppliedCorrectlyAtDeeperLevels()
-    {
-        var utilitiesCount = RandomizationHelper.RandomInteger(3, 10);
-        var setup = new EnvironmentSetup("outer_demands_env");
-        setup.WithCategory("FL1", 1).WithCategory("SL1", 1).WithCategory("SL2", utilitiesCount).WithCategory("TL1", utilitiesCount);
-        setup.WithRequirements("FL1", 1, "SL1", "SL2").WithRequirements("SL1", 1, "TL1");
-
-        for (var i = 1; i <= utilitiesCount; i++)
-        {
-            var characteristic = $"C-{i}";
-            setup.WithCharacteristics("SL2", i, characteristic);
-            setup.WithOuterDemands("TL1", i, "SL2", characteristic);
-        }
-
-        var assemblyTestData = setup.MaterializeAsAssemblyData();
-        var manager = new ConstructionManager(assemblyTestData);
-
-        var fl1Utilities = assemblyTestData.CleanUtilities.Get("FL1").ToArray();
-        Assert.Single(fl1Utilities);
-
-        var sl1Utilities = assemblyTestData.CleanUtilities.Get("SL1").ToArray();
-        Assert.Single(sl1Utilities);
-
-        var sl2Utilities = assemblyTestData.CleanUtilities.Get("SL2").ToArray();
-        Assert.Equal(utilitiesCount, sl2Utilities.Length);
-
-        var tl1Utilities = assemblyTestData.CleanUtilities.Get("TL1").ToArray();
-        Assert.Equal(utilitiesCount, tl1Utilities.Length);
-
-        var utilityIds = new[] { fl1Utilities[0].Id };
-        var constructionGraphs = manager.BuildIndividualConstructionGraphs(utilityIds);
-
-        Assert.Equal(utilitiesCount, constructionGraphs.Length);
-        for (var i = 0; i < utilitiesCount; i++)
-        {
-            var fl1ConstructionGraph = constructionGraphs[i][0];
-
-            Assert.NotNull(fl1Utilities);
-            Assert.Equal(fl1Utilities[0].Id, fl1ConstructionGraph.Id);
-            Assert.Equal(2, fl1ConstructionGraph.Dependencies.Count);
-
-            var sl1ConstructionGraph = fl1ConstructionGraph.Dependencies[0];
-            Assert.NotNull(sl1ConstructionGraph);
-            Assert.Equal(sl1Utilities[0].Id, sl1ConstructionGraph.Id);
-
-            var sl2ConstructionGraph = fl1ConstructionGraph.Dependencies[1];
-            Assert.NotNull(sl2ConstructionGraph);
-            Assert.Equal(sl2Utilities[i].Id, sl2ConstructionGraph.Id);
-            Assert.Empty(sl2ConstructionGraph.Dependencies);
-
-            var tl1ConstructionGraph = Assert.Single(sl1ConstructionGraph.Dependencies);
-            Assert.NotNull(tl1ConstructionGraph);
-            Assert.Equal(tl1Utilities[i].Id, tl1ConstructionGraph.Id);
-            Assert.Empty(tl1ConstructionGraph.Dependencies);
-        }
-    }
-    
-    [Fact]
     public void UnsatisfiableOuterDemandsShouldBeHandledCorrectlyAtDeeperLevels()
     {
         var utilitiesCount = RandomizationHelper.RandomInteger(3, 10);
@@ -196,12 +139,92 @@ public class ConstructionManagerTests
         Assert.Empty(constructionGraphs);
     }
 
+    /// <remarks>
+    /// |N0| -> |N1| -> ... |N{depth - 2}| -> |N{depth - 1}| -> |N{depth}|
+    ///                                    -> |Q|
+    ///
+    /// N{depth} defines outer demands towards Q
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(GetDepthMembers))]
+    public void OuterDemandsShouldBeAppliedCorrectlyAtDeeperLevels(int depth)
+    {
+        var utilitiesCount = RandomizationHelper.RandomInteger(3, 10);
+        var setup = new EnvironmentSetup("outer_demands_env");
+
+        for (var i = 0; i < depth; i++)
+        {
+            setup.WithCategory($"N{i}", 1);
+            setup.WithRequirements($"N{i}", 1, $"N{i + 1}");
+        }
+
+        setup.WithCategory($"N{depth}", utilitiesCount).WithCategory("Q", utilitiesCount);
+        setup.WithRequirements($"N{depth - 2}", 1, "Q");
+
+        for (var i = 1; i <= utilitiesCount; i++)
+        {
+            setup.WithCharacteristics("Q", i, $"C{i}");
+            setup.WithOuterDemands($"N{depth}", i, "Q", $"C{i}");
+        }
+
+        var assemblyTestData = setup.MaterializeAsAssemblyData();
+        var manager = new ConstructionManager(assemblyTestData);
+
+        // NOTE: There are depth + 1 `N#` categories and `Q`.
+        var utilitiesMatrix = new ICleanUtilityDescriptor[depth + 2][];
+        for (var i = 0; i <= depth; i++) utilitiesMatrix[i] = assemblyTestData.CleanUtilities.Get($"N{i}").ToArray();
+        utilitiesMatrix[^1] = assemblyTestData.CleanUtilities.Get("Q").ToArray();
+
+        for (var i = 0; i < depth; i++) Assert.Single(utilitiesMatrix[i]);
+        for (var i = depth; i < utilitiesMatrix.Length; i++) Assert.Equal(utilitiesCount, utilitiesMatrix[i].Length);
+
+        var utilityIds = new[] { utilitiesMatrix[0][0].Id };
+        var constructionGraphs = manager.BuildIndividualConstructionGraphs(utilityIds);
+        
+        Assert.Equal(utilitiesCount, constructionGraphs.Length);
+        for (var i = 0; i < utilitiesCount; i++)
+        {
+            var constructionGraph = constructionGraphs[i][0];
+
+            for (var j = 0; j < depth - 2; j++)
+            {
+                Assert.Equal(utilitiesMatrix[j][0].Id, constructionGraph.Id);
+                Assert.Single(constructionGraph.Dependencies);
+
+                constructionGraph = constructionGraph.Dependencies[0];
+            }
+            
+            Assert.Equal(utilitiesMatrix[depth - 2][0].Id, constructionGraph.Id);
+            Assert.Equal(2, constructionGraph.Dependencies.Count);
+        
+            var penultConstructionGraph = constructionGraph.Dependencies[0];
+            Assert.Equal(utilitiesMatrix[depth - 1][0].Id, penultConstructionGraph.Id);
+            Assert.Single(penultConstructionGraph.Dependencies);
+        
+            var qConstructionGraph = constructionGraph.Dependencies[1];
+            Assert.Equal(utilitiesMatrix[^1][i].Id, qConstructionGraph.Id);
+            Assert.Empty(qConstructionGraph.Dependencies);
+        
+            var lastConstructionGraph = penultConstructionGraph.Dependencies[0];
+            Assert.Equal(utilitiesMatrix[depth][i].Id, lastConstructionGraph.Id);
+            Assert.Empty(lastConstructionGraph.Dependencies);
+        }
+    }
+
     public static TheoryData<EnvironmentSetup, string> GetDependenciesManagerSetups()
     {
         var data = new TheoryData<EnvironmentSetup, string>();
         foreach (var dependenciesManagerSetup in TestParameters.ConstructObservableConstructionManagerSetups())
             data.Add(dependenciesManagerSetup.EnvironmentSetup, dependenciesManagerSetup.PathToExpectedResult);
-        
+
+        return data;
+    }
+
+    public static TheoryData<int> GetDepthMembers()
+    {
+        var data = new TheoryData<int>();
+        for (var i = 2; i <= 10; i++) data.Add(i);
+
         return data;
     }
 }

--- a/TryAtSoftware.CleanTests.Core/Attributes/ExternalDemandsAttribute.cs
+++ b/TryAtSoftware.CleanTests.Core/Attributes/ExternalDemandsAttribute.cs
@@ -3,10 +3,4 @@
 using System;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-public class ExternalDemandsAttribute : BaseDemandsAttribute
-{
-    public ExternalDemandsAttribute(string category, params string[] demands)
-        : base(category, demands)
-    {
-    }
-}
+public class ExternalDemandsAttribute(string category, params string[] demands) : BaseDemandsAttribute(category, demands);

--- a/TryAtSoftware.CleanTests.Core/Attributes/InternalDemandsAttribute.cs
+++ b/TryAtSoftware.CleanTests.Core/Attributes/InternalDemandsAttribute.cs
@@ -3,10 +3,4 @@
 using System;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-public class InternalDemandsAttribute : BaseDemandsAttribute
-{
-    public InternalDemandsAttribute(string category, params string[] demands)
-        : base(category, demands)
-    {
-    }
-}
+public class InternalDemandsAttribute(string category, params string[] demands) : BaseDemandsAttribute(category, demands);

--- a/TryAtSoftware.CleanTests.Core/Attributes/OuterDemandsAttribute.cs
+++ b/TryAtSoftware.CleanTests.Core/Attributes/OuterDemandsAttribute.cs
@@ -3,10 +3,4 @@
 using System;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-public class OuterDemandsAttribute : BaseDemandsAttribute
-{
-    public OuterDemandsAttribute(string category, params string[] demands)
-        : base(category, demands)
-    {
-    }
-}
+public class OuterDemandsAttribute(string category, params string[] demands) : BaseDemandsAttribute(category, demands);


### PR DESCRIPTION
## Pull Request Description 

Extended the existing tests covering the functionality of `outer demands`.

## Motivation and Context

This is a relatively complex way of defining demands to model the relationships between clean tests utilities. That's why we need more tests to ensure its stability and increase the understanding capabilities.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
