### PR TITLE
Add support for .NET 10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,10 +30,9 @@ jobs:
               uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: |
-                      6.x
-                      7.x
                       8.x
                       9.x
+                      10.x
 
             - name: Set up JDK 11
               uses: actions/setup-java@v4

--- a/.github/workflows/Publish packages.yml
+++ b/.github/workflows/Publish packages.yml
@@ -20,10 +20,9 @@ jobs:
               uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: |
-                      6.x
-                      7.x
                       8.x
                       9.x
+                      10.x
 
             - name: Restore dependencies
               run: dotnet restore

--- a/Samples/Calculator/Calculator.API/Calculator.API.csproj
+++ b/Samples/Calculator/Calculator.API/Calculator.API.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+      <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Samples/Calculator/Calculator.API/Controllers/V1/TriangleController.cs
+++ b/Samples/Calculator/Calculator.API/Controllers/V1/TriangleController.cs
@@ -3,6 +3,7 @@
 using Calculator.API.InputModels.V1;
 using Calculator.API.OutputModels;
 using Calculator.API.OutputModels.V1;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
 [ApiController, ApiVersion("1.0"), ApiVersion("2.0"), Route("api/v{version:apiVersion}/triangle")]

--- a/Samples/Calculator/Calculator.API/Controllers/V2/RectangleController.cs
+++ b/Samples/Calculator/Calculator.API/Controllers/V2/RectangleController.cs
@@ -2,6 +2,7 @@
 
 using Calculator.API.InputModels.V2;
 using Calculator.API.OutputModels.V1;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
 [ApiController, ApiVersion("2.0"), Route("api/v{version:apiVersion}/rectangle")]

--- a/Samples/Calculator/Calculator.API/Program.cs
+++ b/Samples/Calculator/Calculator.API/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc.Versioning;
+using Asp.Versioning;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddApiVersioning(

--- a/Samples/Calculator/Calculator.API/Program.cs
+++ b/Samples/Calculator/Calculator.API/Program.cs
@@ -13,7 +13,3 @@ var app = builder.Build();
 
 app.MapControllers();
 app.Run();
-
-#pragma warning disable S1118 // This class is needed for API tests
-public partial class Program {}
-#pragma warning restore S1118

--- a/Samples/Calculator/Calculator.CleanTests/Calculator.CleanTests.csproj
+++ b/Samples/Calculator/Calculator.CleanTests/Calculator.CleanTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -10,20 +10,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.3">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="TryAtSoftware.Equalizer" Version="1.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="TryAtSoftware.Equalizer" Version="1.0.2" />
         <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.2" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.3">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Samples/Job Agency/JobAgency.CleanTests/JobAgency.CleanTests.csproj
+++ b/Samples/Job Agency/JobAgency.CleanTests/JobAgency.CleanTests.csproj
@@ -1,26 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.3">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="TryAtSoftware.Equalizer" Version="1.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="TryAtSoftware.Equalizer" Version="1.0.2" />
         <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.2" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.3">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Samples/Job Agency/JobAgency.CleanTests/JobAgencyCleanTest.cs
+++ b/Samples/Job Agency/JobAgency.CleanTests/JobAgencyCleanTest.cs
@@ -19,14 +19,9 @@ using Xunit.Abstractions;
 
 [Collection("Job agency clean tests collection")]
 [WithRequirements(CleanUtilitiesCategories.Database)]
-public abstract class JobAgencyCleanTest : CleanTest
+public abstract class JobAgencyCleanTest(ITestOutputHelper testOutputHelper) : CleanTest(testOutputHelper)
 {
     private int _databaseId;
-
-    protected JobAgencyCleanTest(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
-    }
 
     protected IDatabaseManager DatabaseManager => this.GetGlobalService<IDatabaseManager>();
     protected IModelBuilder<IJobAgency, Nothing> JobAgencyModelBuilder => this.GetService<IModelBuilder<IJobAgency, Nothing>>();
@@ -40,10 +35,10 @@ public abstract class JobAgencyCleanTest : CleanTest
         this.InitializeGlobalDependenciesProvider();
 
         this._databaseId = await this.DatabaseManager.GetDatabaseIdAsync(this.GetCancellationToken());
-        
+
         this.DatabaseManager.SetupEntities();
         this.DatabaseManager.RegisterDependencies(this._databaseId, this.LocalDependenciesCollection);
-        
+
         this.InitializeLocalDependenciesProvider();
     }
 
@@ -84,19 +79,19 @@ public abstract class JobAgencyCleanTest : CleanTest
         var equalizationProfileProvider = new DedicatedProfileProvider();
         RegisterGeneralEqualizationProfile<IJobAgency>();
         RegisterGeneralEqualizationProfile<IJobOffer>();
-        
+
         // Benefits
         RegisterGeneralEqualizationProfile<CanHaveMoreFreeDays>();
         RegisterGeneralEqualizationProfile<CanHavePerformanceBonus>();
         RegisterGeneralEqualizationProfile<CanUseInsurance>();
         RegisterGeneralEqualizationProfile<CanUseMultiSportCard>();
-        
+
         // Requirements
         RegisterGeneralEqualizationProfile<MustHaveDrivingLicense>();
         RegisterGeneralEqualizationProfile<MustHaveEducation>();
         RegisterGeneralEqualizationProfile<MustHaveMinimumExperience>();
         RegisterGeneralEqualizationProfile<MustWorkFromOffice>();
-        
+
         equalizer.AddProfileProvider(equalizationProfileProvider);
         return equalizer;
 

--- a/Samples/Job Agency/JobAgency.Data/JobAgency.Data.csproj
+++ b/Samples/Job Agency/JobAgency.Data/JobAgency.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
@@ -10,8 +10,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-      <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+      <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
     </ItemGroup>
 
 </Project>

--- a/Samples/Job Agency/JobAgency.Models/JobAgency.Models.csproj
+++ b/Samples/Job Agency/JobAgency.Models/JobAgency.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 

--- a/Tests/TryAtSoftware.CleanTests.Benchmark/CombinatorialMachineBenchmark.cs
+++ b/Tests/TryAtSoftware.CleanTests.Benchmark/CombinatorialMachineBenchmark.cs
@@ -21,7 +21,7 @@ using TryAtSoftware.CleanTests.UnitTests.Parametrization;
 | GenerateAllCombinations | Setup #8 |      22.56 us |     0.163 us |     0.153 us |
 | GenerateAllCombinations | Setup #9 |      80.94 us |     0.447 us |     0.396 us |
  */
-internal class CombinatorialMachineBenchmark
+public class CombinatorialMachineBenchmark
 {
     private CombinatorialMachine _machine;
 

--- a/Tests/TryAtSoftware.CleanTests.Benchmark/ConstructionManagerBenchmark.cs
+++ b/Tests/TryAtSoftware.CleanTests.Benchmark/ConstructionManagerBenchmark.cs
@@ -20,7 +20,7 @@ using TryAtSoftware.CleanTests.UnitTests.Parametrization;
 | BuildConstructionGraphs | Setup #6 |     24.91 us |   0.175 us |   0.164 us |    6.0425 |   0.1221 |        - |    49.47 KB |
  */
 [MemoryDiagnoser]
-internal class ConstructionManagerBenchmark
+public class ConstructionManagerBenchmark
 {
     private CleanTestAssemblyData _assemblyData;
 

--- a/Tests/TryAtSoftware.CleanTests.Benchmark/TryAtSoftware.CleanTests.Benchmark.csproj
+++ b/Tests/TryAtSoftware.CleanTests.Benchmark/TryAtSoftware.CleanTests.Benchmark.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Tests/TryAtSoftware.CleanTests.UnitTests/TryAtSoftware.CleanTests.UnitTests.csproj
+++ b/Tests/TryAtSoftware.CleanTests.UnitTests/TryAtSoftware.CleanTests.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -14,26 +14,22 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.3">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.2" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.3">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="PolySharp" Version="1.15.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
+++ b/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
@@ -36,17 +36,14 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
+++ b/TryAtSoftware.CleanTests.Core/TryAtSoftware.CleanTests.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <IsTestProject>false</IsTestProject>
@@ -25,23 +25,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.4.0.108396">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="TryAtSoftware.Extensions.Collections" Version="1.1.0" />
         <PackageReference Include="TryAtSoftware.Extensions.Reflection" Version="1.1.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -52,6 +42,11 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TryAtSoftware.CleanTests.Sample.Mathematics/TryAtSoftware.CleanTests.Sample.Mathematics.csproj
+++ b/TryAtSoftware.CleanTests.Sample.Mathematics/TryAtSoftware.CleanTests.Sample.Mathematics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/TryAtSoftware.CleanTests.Sample/TryAtSoftware.CleanTests.Sample.csproj
+++ b/TryAtSoftware.CleanTests.Sample/TryAtSoftware.CleanTests.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -9,17 +9,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.3">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.3">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
## Pull Request Description 

Added support for .NET 10.
Removed support for .NET 6 and 7, as well as .NET Standard 2.1.
Updated all referenced packages.

## Motivation and Context

The `TryAtSoftware.CleanTests` NuGet package must innovate.

## Checklist

- [x] I have tested these changes thoroughly.
- [ ] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [ ] My changes are backwards compatible.
